### PR TITLE
Add script to run multiple bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Reaper Gaming Profile Discord Bots
+
+This repository contains three simple Discord bots that can be run from your desktop.
+Each bot has a unique personality and command prefix.
+
+## Bots Included
+
+- **GrimBot** (`!` prefix) - Greets users in a spooky style.
+- **CurseBot** (`?` prefix) - Playfully curses the user on command.
+- **BloomBot** (`&` prefix) - Spreads good vibes to everyone.
+
+## Requirements
+
+- Python 3.11+
+- `discord.py` (see `requirements.txt`)
+
+Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running a Bot
+
+Use `run.py` to start any of the bots. Provide the name of the bot and a Discord token
+(either via `--token` or the `DISCORD_TOKEN` environment variable).
+
+```bash
+python run.py grimbot --token YOUR_TOKEN_HERE
+```
+
+Replace `grimbot` with `cursebot` or `bloombot` to run the other bots.
+
+## Running Multiple Bots Together
+
+You can launch more than one bot at the same time using `run_all.py`. Provide the
+tokens via command line flags or environment variables (`GRIMBOT_TOKEN`,
+`CURSEBOT_TOKEN`, `BLOOMBOT_TOKEN`). Any bots without tokens will not be started.
+
+```bash
+python run_all.py --grimbot-token TOKEN1 --cursebot-token TOKEN2
+```
+
+The example above starts GrimBot and CurseBot concurrently.
+
+## About Reaper Gaming Profile
+
+All of these bots are configured for the Reaper Gaming Profile project.
+Feel free to modify or extend them to suit your Discord server.

--- a/bots/bloombot.py
+++ b/bots/bloombot.py
@@ -1,0 +1,17 @@
+import discord
+from discord.ext import commands
+
+class BloomBot(commands.Bot):
+    def __init__(self):
+        intents = discord.Intents.default()
+        intents.message_content = True
+        super().__init__(command_prefix="&", intents=intents)
+        self.add_command(self.bloom)
+
+    async def on_ready(self):
+        print(f"BloomBot connected as {self.user}")
+
+    @commands.command()
+    async def bloom(self, ctx: commands.Context):
+        """Send a cheerful message."""
+        await ctx.send("BloomBot sends you positive vibes!")

--- a/bots/cursebot.py
+++ b/bots/cursebot.py
@@ -1,0 +1,17 @@
+import discord
+from discord.ext import commands
+
+class CurseBot(commands.Bot):
+    def __init__(self):
+        intents = discord.Intents.default()
+        intents.message_content = True
+        super().__init__(command_prefix="?", intents=intents)
+        self.add_command(self.curse)
+
+    async def on_ready(self):
+        print(f"CurseBot connected as {self.user}")
+
+    @commands.command()
+    async def curse(self, ctx: commands.Context):
+        """Playfully scold the user."""
+        await ctx.send(f"{ctx.author.mention}, you've been cursed!")

--- a/bots/grimbot.py
+++ b/bots/grimbot.py
@@ -1,0 +1,17 @@
+import discord
+from discord.ext import commands
+
+class GrimBot(commands.Bot):
+    def __init__(self):
+        intents = discord.Intents.default()
+        intents.message_content = True
+        super().__init__(command_prefix="!", intents=intents)
+        self.add_command(self.hello)
+
+    async def on_ready(self):
+        print(f"GrimBot connected as {self.user}")
+
+    @commands.command()
+    async def hello(self, ctx: commands.Context):
+        """Respond with a friendly greeting."""
+        await ctx.send("Greetings from GrimBot!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+discord.py>=2.5

--- a/run.py
+++ b/run.py
@@ -1,0 +1,41 @@
+"""Entry point to launch one of the Discord bots."""
+
+import os
+import argparse
+
+from bots.grimbot import GrimBot
+from bots.cursebot import CurseBot
+from bots.bloombot import BloomBot
+
+
+BOTS = {
+    "grimbot": GrimBot,
+    "cursebot": CurseBot,
+    "bloombot": BloomBot,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a Discord bot")
+    parser.add_argument(
+        "bot",
+        choices=BOTS.keys(),
+        help="Which bot to run (grimbot, cursebot, bloombot)",
+    )
+    parser.add_argument(
+        "--token",
+        help="Discord bot token. Can also be provided via DISCORD_TOKEN env var",
+    )
+    args = parser.parse_args()
+
+    token = args.token or os.environ.get("DISCORD_TOKEN")
+    if not token:
+        raise SystemExit("A Discord token must be provided via --token or DISCORD_TOKEN env var")
+
+    bot_cls = BOTS[args.bot]
+    bot = bot_cls()
+    bot.run(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_all.py
+++ b/run_all.py
@@ -1,0 +1,33 @@
+import argparse
+import asyncio
+import os
+
+from bots.grimbot import GrimBot
+from bots.cursebot import CurseBot
+from bots.bloombot import BloomBot
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Run multiple Discord bots")
+    parser.add_argument("--grimbot-token", default=os.getenv("GRIMBOT_TOKEN"),
+                        help="Token for GrimBot")
+    parser.add_argument("--cursebot-token", default=os.getenv("CURSEBOT_TOKEN"),
+                        help="Token for CurseBot")
+    parser.add_argument("--bloombot-token", default=os.getenv("BLOOMBOT_TOKEN"),
+                        help="Token for BloomBot")
+    args = parser.parse_args()
+
+    tasks = []
+    if args.grimbot_token:
+        tasks.append(GrimBot().start(args.grimbot_token))
+    if args.cursebot_token:
+        tasks.append(CurseBot().start(args.cursebot_token))
+    if args.bloombot_token:
+        tasks.append(BloomBot().start(args.bloombot_token))
+
+    if not tasks:
+        parser.error("At least one bot token must be provided")
+
+    await asyncio.gather(*tasks)
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `run_all.py` to launch GrimBot, CurseBot and BloomBot together
- document how to run multiple bots in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6886c01319708321a257a32f1d1ef68f