### PR TITLE
Add multi-bot setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Python virtual environment
+venv/
+__pycache__/
+
+# Environment files
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Grimmbot Multi-Bot Setup
+
+This project contains three simple Discord bots using OpenAI API. Each bot runs from its own file inside the `bots/` directory.
+
+## Setup
+
+1. Copy `config.env.example` to `.env` and fill in your Discord tokens and API keys.
+2. Run `./setup.sh` to create a Python virtual environment and install dependencies.
+3. Start all bots with `./run.sh`.
+
+## Files
+
+- `bots/bot1.py`, `bots/bot2.py`, `bots/bot3.py` – individual bot scripts
+- `setup.sh` – create virtual environment and install requirements
+- `run.sh` – launch all bots using the credentials from `.env`
+
+Each bot responds to messages starting with `!bot1`, `!bot2`, or `!bot3` respectively, using the text after that command as a prompt for OpenAI.

--- a/bots/bot1.py
+++ b/bots/bot1.py
@@ -1,0 +1,40 @@
+import dotenv; dotenv.load_dotenv()
+import os
+import discord
+import asyncio
+import openai
+
+TOKEN = os.getenv('DISCORD_TOKEN_BOT1')
+OPENAI_KEY = os.getenv('OPENAI_API_KEY_BOT1')
+
+openai.api_key = OPENAI_KEY
+
+intents = discord.Intents.default()
+client = discord.Client(intents=intents)
+
+@client.event
+async def on_ready():
+    print(f"bot1 logged in as {client.user}")
+
+@client.event
+async def on_message(message):
+    if message.author.bot:
+        return
+    if message.content.startswith('!bot1'):
+        prompt = message.content[len('!bot1'):].strip()
+        if not prompt:
+            await message.channel.send('Hello from bot1!')
+            return
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}]
+        )
+        await message.channel.send(response.choices[0].message.content)
+
+def main():
+    if not TOKEN:
+        raise ValueError('DISCORD_TOKEN_BOT1 is not set')
+    client.run(TOKEN)
+
+if __name__ == '__main__':
+    main()

--- a/bots/bot2.py
+++ b/bots/bot2.py
@@ -1,0 +1,39 @@
+import dotenv; dotenv.load_dotenv()
+import os
+import discord
+import openai
+
+TOKEN = os.getenv('DISCORD_TOKEN_BOT2')
+OPENAI_KEY = os.getenv('OPENAI_API_KEY_BOT2')
+
+openai.api_key = OPENAI_KEY
+
+intents = discord.Intents.default()
+client = discord.Client(intents=intents)
+
+@client.event
+async def on_ready():
+    print(f"bot2 logged in as {client.user}")
+
+@client.event
+async def on_message(message):
+    if message.author.bot:
+        return
+    if message.content.startswith('!bot2'):
+        prompt = message.content[len('!bot2'):].strip()
+        if not prompt:
+            await message.channel.send('Hello from bot2!')
+            return
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}]
+        )
+        await message.channel.send(response.choices[0].message.content)
+
+def main():
+    if not TOKEN:
+        raise ValueError('DISCORD_TOKEN_BOT2 is not set')
+    client.run(TOKEN)
+
+if __name__ == '__main__':
+    main()

--- a/bots/bot3.py
+++ b/bots/bot3.py
@@ -1,0 +1,39 @@
+import dotenv; dotenv.load_dotenv()
+import os
+import discord
+import openai
+
+TOKEN = os.getenv('DISCORD_TOKEN_BOT3')
+OPENAI_KEY = os.getenv('OPENAI_API_KEY_BOT3')
+
+openai.api_key = OPENAI_KEY
+
+intents = discord.Intents.default()
+client = discord.Client(intents=intents)
+
+@client.event
+async def on_ready():
+    print(f"bot3 logged in as {client.user}")
+
+@client.event
+async def on_message(message):
+    if message.author.bot:
+        return
+    if message.content.startswith('!bot3'):
+        prompt = message.content[len('!bot3'):].strip()
+        if not prompt:
+            await message.channel.send('Hello from bot3!')
+            return
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}]
+        )
+        await message.channel.send(response.choices[0].message.content)
+
+def main():
+    if not TOKEN:
+        raise ValueError('DISCORD_TOKEN_BOT3 is not set')
+    client.run(TOKEN)
+
+if __name__ == '__main__':
+    main()

--- a/config.env.example
+++ b/config.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your API keys and tokens
+DISCORD_TOKEN_BOT1=
+DISCORD_TOKEN_BOT2=
+DISCORD_TOKEN_BOT3=
+OPENAI_API_KEY_BOT1=
+OPENAI_API_KEY_BOT2=
+OPENAI_API_KEY_BOT3=

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+discord.py
+openai
+
+python-dotenv

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+source venv/bin/activate
+
+# load environment variables
+if [ -f .env ]; then
+    export $(grep -v '^#' .env | xargs)
+fi
+
+python bots/bot1.py &
+python bots/bot2.py &
+python bots/bot3.py &
+
+wait

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+
+echo "Setup complete. Edit .env with your tokens."


### PR DESCRIPTION
## Summary
- add README instructions
- add python discord bot scripts for three bots
- add setup.sh and run.sh for easy installation & running
- include example environment file and requirements

## Testing
- `./setup.sh`
- `python -m py_compile bots/bot1.py bots/bot2.py bots/bot3.py`


------
https://chatgpt.com/codex/tasks/task_e_6886c8be925c8321952b413887b5f719