### PR TITLE
Add credential template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+# Ignore credentials file
+bot_credentials.yml

--- a/bot_credentials.example.yml
+++ b/bot_credentials.example.yml
@@ -1,0 +1,15 @@
+# Example credentials file for three bots.
+# Copy this file to 'bot_credentials.yml' and replace the placeholder
+# values with your actual tokens and API keys.
+
+bot1:
+  token: "YOUR_BOT1_TOKEN"
+  api_key: "YOUR_BOT1_API_KEY"
+
+bot2:
+  token: "YOUR_BOT2_TOKEN"
+  api_key: "YOUR_BOT2_API_KEY"
+
+bot3:
+  token: "YOUR_BOT3_TOKEN"
+  api_key: "YOUR_BOT3_API_KEY"


### PR DESCRIPTION
## Summary
- add a credentials template for all three bots with token fields
- ignore the actual credentials file via `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886c2eea55c8321bee58e01af53b328