### PR TITLE
Implement minimal multi-bot framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Grimmbot
+
+This repository contains simple example bots that can be chained together.
+
+## Installation
+
+```
+pip install -e .
+```
+
+## Usage
+
+```
+$ grimmbot "hello world" -b echo reverse upper
+DLROW OLLEH
+```

--- a/grimmbot/__init__.py
+++ b/grimmbot/__init__.py
@@ -1,0 +1,15 @@
+"""Grimmbot package with simple example bots."""
+
+from .bot import Bot
+from .echo_bot import EchoBot
+from .reverse_bot import ReverseBot
+from .uppercase_bot import UppercaseBot
+from .coordinator import Coordinator
+
+__all__ = [
+    'Bot',
+    'EchoBot',
+    'ReverseBot',
+    'UppercaseBot',
+    'Coordinator',
+]

--- a/grimmbot/bot.py
+++ b/grimmbot/bot.py
@@ -1,0 +1,5 @@
+class Bot:
+    """Base bot class."""
+    def process(self, message: str) -> str:
+        """Process a message and return the response."""
+        raise NotImplementedError("Bots must implement process()")

--- a/grimmbot/cli.py
+++ b/grimmbot/cli.py
@@ -1,0 +1,27 @@
+import argparse
+
+from .echo_bot import EchoBot
+from .reverse_bot import ReverseBot
+from .uppercase_bot import UppercaseBot
+from .coordinator import Coordinator
+
+BOT_MAP = {
+    'echo': EchoBot,
+    'reverse': ReverseBot,
+    'upper': UppercaseBot,
+}
+
+def main():
+    parser = argparse.ArgumentParser(description='Run a chain of simple bots.')
+    parser.add_argument('message', help='Message to process')
+    parser.add_argument('-b', '--bots', nargs='+', choices=list(BOT_MAP.keys()), default=['echo'],
+                        help='Bots to apply in sequence')
+    args = parser.parse_args()
+
+    bots = [BOT_MAP[name]() for name in args.bots]
+    coordinator = Coordinator(bots)
+    result = coordinator.process(args.message)
+    print(result)
+
+if __name__ == '__main__':
+    main()

--- a/grimmbot/coordinator.py
+++ b/grimmbot/coordinator.py
@@ -1,0 +1,14 @@
+from typing import List
+
+from .bot import Bot
+
+class Coordinator:
+    """Coordinate multiple bots to process messages sequentially."""
+    def __init__(self, bots: List[Bot]):
+        self.bots = bots
+
+    def process(self, message: str) -> str:
+        """Pass the message through all bots in sequence."""
+        for bot in self.bots:
+            message = bot.process(message)
+        return message

--- a/grimmbot/echo_bot.py
+++ b/grimmbot/echo_bot.py
@@ -1,0 +1,6 @@
+from .bot import Bot
+
+class EchoBot(Bot):
+    """A bot that echoes the user's message."""
+    def process(self, message: str) -> str:
+        return message

--- a/grimmbot/reverse_bot.py
+++ b/grimmbot/reverse_bot.py
@@ -1,0 +1,6 @@
+from .bot import Bot
+
+class ReverseBot(Bot):
+    """A bot that reverses the user's message."""
+    def process(self, message: str) -> str:
+        return message[::-1]

--- a/grimmbot/uppercase_bot.py
+++ b/grimmbot/uppercase_bot.py
@@ -1,0 +1,6 @@
+from .bot import Bot
+
+class UppercaseBot(Bot):
+    """A bot that converts messages to uppercase."""
+    def process(self, message: str) -> str:
+        return message.upper()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[metadata]
+name = grimmbot
+version = 0.1.0
+author = The-w0rst
+description = Simple demo bots working together
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+[options]
+packages = find:
+python_requires = >=3.8
+install_requires = []
+
+[options.entry_points]
+console_scripts =
+    grimmbot = grimmbot.cli:main

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
## Summary
- add a small `grimmbot` package with base Bot class
- implement example bots (echo, reverse, uppercase)
- add Coordinator and CLI to chain bots together
- provide packaging via `setup.cfg` and instructions in README

## Testing
- `python -m grimmbot.cli "test" -b echo reverse upper`

------
https://chatgpt.com/codex/tasks/task_e_6886c12a93e48321b4d055bf4d354d6b