### PR TITLE
Add environment setup template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env and fill in your credentials
+# Discord bot token
+DISCORD_TOKEN=
+# Generic API key
+API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Setup Guide
+
+This repository expects your API credentials in a local `.env` file. An example file is provided as `.env.example`.
+
+1. Copy `.env.example` to `.env`:
+   
+   ```sh
+   cp .env.example .env
+   ```
+
+2. Open `.env` in a text editor and fill in your personal API keys and tokens.
+
+The application code should load these variables from `.env` so you never commit your secrets to version control.
+


### PR DESCRIPTION
## Summary
- ignore `.env` files
- add `.env.example` template for API keys
- provide setup steps in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886c26cee0c8321ac7e888c84fed565