### PR TITLE
Improve README commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,51 @@ tokens live in the `config/` directory:
 
 Fill in each file with the three API keys and Discord token for its bot before
 starting the bots.
+
+## Running the Bots
+
+After configuring the `.env` files, launch a bot with Python:
+
+```bash
+python grimm_bot.py    # prefix: !
+python bloom_bot.py    # prefix: *
+python curse_bot.py    # prefix: !
+```
+
+## Command Reference
+
+### GrimmBot
+- `!protectbloom` – defend Bloom from imaginary threats.
+- `!roast [@user]` – deliver a grumpy roast.
+- `!goon` – call the goon squad.
+- `!ominous` – send an ominous quip.
+- `!bloom` – comments about Bloom.
+- `!curse` – comments about Curse.
+- `!scythe` – dramatic scythe swing.
+- `!shadow` – send a spooky shadow.
+- `!flip [@user]` – flip a user.
+- `!brood` – quietly brood.
+- `!bone` – offer a skeletal joke.
+- `!shield [@user]` – provide mock protection.
+
+### BloomBot
+Commands use the `*` prefix:
+- `*hug` – give a hug.
+- `*sing` – burst into song.
+- `*grimm` – talk about Grimm.
+- `*curse` – tease Curse.
+- `*cheer` – offer encouragement.
+- `*sparkle` – throw confetti.
+- `*drama` – start a musical.
+- `*bloom` – introduce Bloom.
+- `*mood` – display Bloom's mood.
+- `*improv` – begin improv.
+- `*squad` – list the goon squad.
+
+### CurseBot
+- `!curse @user` – manually curse a user (admin only).
+- `!whois_cursed` – check the currently cursed user.
+- `!sushi` – mention sushi.
+- `!flick` – flick the tail.
+- `!insult` – deliver an insult.
+


### PR DESCRIPTION
## Summary
- document running bots
- add command lists for all bots

## Testing
- `python -m py_compile grimm_bot.py bloom_bot.py curse_bot.py the-worst-grimbot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6886d87368c08321ba9c73c5f1639291