### PR TITLE
Update CurseBot with extra taunts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Commands use the `*` prefix:
 - `!sushi` – mention sushi.
 - `!flick` – flick the tail.
 - `!insult` – deliver an insult.
+- `!hiss` – hiss at the server.
+- `!scratch [@user]` – scratch someone just because.
+- `!curse_me` – willingly take the curse.
 
 ## Developing your own bots
 

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -71,7 +71,10 @@ curse_responses = [
     "Did you really think that would work? Cursed move.",
     "I’d help, but I’m morally opposed to effort.",
     "You're cursed. Figure it out. 😽",
-    "Lick my paw and mind your business."
+    "Lick my paw and mind your business.",
+    "Hope you like hairballs in your shoes.",
+    "Your luck is as bad as your taste in cat food.",
+    "May your pillow forever smell of catnip."
 ]
 
 # === Keywords ===
@@ -81,7 +84,10 @@ curse_keywords = {
     "sushi": ["BACK OFF. It’s mine."],
     "pet": ["Touch me and lose a finger."],
     "curse": ["You rang? Someone's getting hexed."],
-    "meow": ["I'm not cute. I’m cursed. Get it right."]
+    "meow": ["I'm not cute. I’m cursed. Get it right."],
+    "tuna": ["Step away from the tuna."],
+    "treat": ["No treats for you."],
+    "cursed": ["Curse intensifies."]
 }
 
 # === On Ready ===
@@ -147,5 +153,21 @@ async def insult(ctx):
         "Your aura is soggy cardboard." 
     ]
     await ctx.send(random.choice(burns))
+
+@bot.command()
+async def hiss(ctx):
+    await ctx.send("Hissss! Keep your distance.")
+
+@bot.command()
+async def scratch(ctx, member: discord.Member = None):
+    member = member or ctx.author
+    await ctx.send(f"*scratches {member.display_name} just because*")
+
+@bot.command()
+async def curse_me(ctx):
+    global cursed_user_id, cursed_user_name
+    cursed_user_id = ctx.author.id
+    cursed_user_name = ctx.author.display_name
+    await ctx.send(f"😾 Fine. {ctx.author.display_name} is now cursed.")
 
 bot.run(DISCORD_TOKEN)


### PR DESCRIPTION
## Summary
- expand random curse responses
- add new keyword triggers
- add `hiss`, `scratch` and `curse_me` commands
- document new CurseBot commands

## Testing
- `python -m py_compile curse_bot.py grimm_bot.py bloom_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6886e03b3dc88321979e5a47eda1148f