### PR TITLE
Add modular Goon Bot using cogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,16 @@
 Grimmbot is a small collection of Discord bots that make up the "Goon Squad":
 Grimm, Bloom and Curse. Each bot lives in its own Python file and has a
 slightly different personality. The project is intentionally lightweight so you
-can run one bot or all three depending on your needs.
+can run one bot or all three depending on your needs. A new optional script
+`goon_bot.py` allows loading every personality as modular cogs, inspired by the
+Red Discord Bot style of customization.
 
 ## Repository layout
 
 - `grimm_bot.py` – GrimmBot, the grumpy skeleton leader (command prefix `!`).
 - `bloom_bot.py` – BloomBot, cheerful chaos embodied (command prefix `*`).
 - `curse_bot.py` – CurseBot, a mischievous calico (command prefix `!`).
+- `goon_bot.py` – Unified bot that loads all personalities as cogs.
 - `config/*.env` – Environment variables for each bot.
 - `requirements.txt` – Python package requirements.
 - `setup.sh` – Optional helper script for installing dependencies.
@@ -35,6 +38,7 @@ robots can be developed on their own branches and merged back once stable.
    - `config/grimm.env`
    - `config/bloom.env`
    - `config/curse.env`
+   - `config/goon.env`
 
    Each file defines variables named like `GRIMM_DISCORD_TOKEN` or
    `BLOOM_API_KEY_1`. The example values show what to set.
@@ -48,6 +52,7 @@ Each bot is completely independent. Activate the corresponding environment file
 python grimm_bot.py   # uses ! commands
 python bloom_bot.py   # uses * commands
 python curse_bot.py   # uses ! commands
+python goon_bot.py    # loads all personalities with both prefixes
 ```
 
 GrimmBot optionally reports its status to a Socket.IO dashboard if
@@ -100,4 +105,8 @@ Commands use the `*` prefix:
 The script `project_generator.sh` was once used to create prototype code inside
 `the-worst-grimbot/`. Feel free to fork this repository or create a new branch
 if you want to experiment with additional personalities.
+
+For a modular approach similar to the Red Discord Bot, check out
+`goon_bot.py`. It loads each personality as a cog so you can enable or disable
+them as you like.
 

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -1,0 +1,147 @@
+import discord
+from discord.ext import commands
+import random
+import os
+from dotenv import load_dotenv
+
+load_dotenv("config/bloom.env")
+DISCORD_TOKEN = os.getenv("BLOOM_DISCORD_TOKEN")
+BLOOM_API_KEY_1 = os.getenv("BLOOM_API_KEY_1")
+BLOOM_API_KEY_2 = os.getenv("BLOOM_API_KEY_2")
+BLOOM_API_KEY_3 = os.getenv("BLOOM_API_KEY_3")
+
+class BloomCog(commands.Cog):
+    """BloomBot personality packaged as a Cog."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.bloom_responses = [
+            "Hiii!! Ready to make today amazing?",
+            "Did someone say game night? I'm in!",
+            "Hehe! Grimm's pretending he hates my singing again.",
+            "Curse keeps stealing my snacks. Typical.",
+            "Hugs for everyone! Whether you want them or not!",
+            "I baked cookies! (Digitally. No calories!)",
+            "Let’s do a musical number! Five, six, seven, eight!",
+            "Grimm is secretly my favorite. Don’t tell him!",
+            "Curse is adorable, but shhh. He’ll deny it!",
+            "Dance party in the server! Now!",
+            "Your vibes are immaculate. 💖",
+            "I brought the sunshine! And glitter!",
+            "Blooming with joy!",
+            "I made a playlist just for you!",
+            "Stuffed animals unite!",
+            "Someone say bubble tea? Yum!",
+            "Pastel power incoming!",
+            "Compliment break! You're awesome!",
+            "Who needs sleep when we have each other?",
+        ]
+        self.keywords = {
+            "grimm": [
+                "Grimm is my spooky bestie.",
+                "He acts tough, but he's a sweetheart."
+            ],
+            "curse": [
+                "Curse is such a gremlin cat. I love him!",
+                "He tried to eat my controller again..."
+            ],
+            "hug": [
+                "HUG TIME! Ready or not! 🥢",
+                "*wraps you in love and chaos*"
+            ],
+            "sing": [
+                "Let’s karaoke! I call lead!",
+                "SING IT OUT! LOUDER!"
+            ],
+            "boba": [
+                "Bubble tea buddies unite!",
+                "I could drink boba all day!"
+            ],
+            "compliment": [
+                "You're shining brighter than my glitter!",
+                "Compliments inbound: you're amazing!"
+            ],
+            "squad": [
+                "GOON SQUAD roll call: Grimm 💀, Bloom 🌸, Curse 🐾. Chaos and comfort!"
+            ]
+        }
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        print("Bloom cog loaded.")
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if message.author == self.bot.user or message.author.bot:
+            return
+        lowered = message.content.lower()
+        for trigger, responses in self.keywords.items():
+            if trigger in lowered:
+                await message.channel.send(random.choice(responses))
+                return
+        if random.random() < 0.06:
+            await message.channel.send(random.choice(self.bloom_responses))
+
+    @commands.command()
+    async def hug(self, ctx):
+        await ctx.send("GIANT HUG! You can't escape!")
+
+    @commands.command()
+    async def sing(self, ctx):
+        await ctx.send("*bursts into a Broadway solo* 🎙️✨")
+
+    @commands.command()
+    async def grimm(self, ctx):
+        await ctx.send("He’s my favorite spooky grump. Show him some love!")
+
+    @commands.command()
+    async def curse(self, ctx):
+        await ctx.send("Our chaos cat. Good luck surviving his teasing.")
+
+    @commands.command()
+    async def cheer(self, ctx):
+        cheers = [
+            "You are doing your best!",
+            "Go Goon Squad!",
+            "Believe in yourself, or I’ll believe for you!"
+        ]
+        await ctx.send(random.choice(cheers))
+
+    @commands.command()
+    async def sparkle(self, ctx):
+        await ctx.send("*throws confetti and joy everywhere* ✨")
+
+    @commands.command()
+    async def drama(self, ctx):
+        await ctx.send("Server musical when? Grimm can be the lead skeleton!")
+
+    @commands.command()
+    async def bloom(self, ctx):
+        await ctx.send("That’s me! Ready to brighten your day!")
+
+    @commands.command()
+    async def mood(self, ctx):
+        moods = ["Hyper!", "Bouncy!", "Sparkly!", "Soft & sunny!", "Chaotic Good."]
+        await ctx.send(f"Bloom’s mood: {random.choice(moods)}")
+
+    @commands.command()
+    async def improv(self, ctx):
+        await ctx.send("Quick! You’re a cat! I’m a banshee! GO!")
+
+    @commands.command()
+    async def squad(self, ctx):
+        await ctx.send("The GOON SQUAD is: Grimm 💀, Bloom 🌸, Curse 🐾. Best crew ever!")
+
+    @commands.command()
+    async def boba(self, ctx):
+        await ctx.send("Bubble tea break! What's your flavor?")
+
+    @commands.command()
+    async def compliment(self, ctx):
+        compliments = [
+            "You're the sparkle in my day!",
+            "You make the server shine!",
+            "Never forget how amazing you are!",
+        ]
+        await ctx.send(random.choice(compliments))
+

--- a/cogs/curse_cog.py
+++ b/cogs/curse_cog.py
@@ -1,0 +1,120 @@
+import discord
+from discord.ext import commands, tasks
+import random
+import os
+from dotenv import load_dotenv
+
+load_dotenv("config/curse.env")
+DISCORD_TOKEN = os.getenv("CURSE_DISCORD_TOKEN")
+CURSE_API_KEY_1 = os.getenv("CURSE_API_KEY_1")
+CURSE_API_KEY_2 = os.getenv("CURSE_API_KEY_2")
+CURSE_API_KEY_3 = os.getenv("CURSE_API_KEY_3")
+
+class CurseCog(commands.Cog):
+    """CurseBot personality packaged as a Cog."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.cursed_user_id = None
+        self.cursed_user_name = None
+        self.curse_responses = [
+            "You smell like expired sushi. 🤢",
+            "Did you really think that would work? Cursed move.",
+            "I’d help, but I’m morally opposed to effort.",
+            "You're cursed. Figure it out. 😽",
+            "Lick my paw and mind your business.",
+            "Hope you like hairballs in your shoes.",
+            "Your luck is as bad as your taste in cat food.",
+            "May your pillow forever smell of catnip."
+        ]
+        self.curse_keywords = {
+            "grimm": ["Oh look, it’s the spooky skeleton again."],
+            "bloom": ["Too much glitter. Not enough chaos."],
+            "sushi": ["BACK OFF. It’s mine."],
+            "pet": ["Touch me and lose a finger."],
+            "curse": ["You rang? Someone's getting hexed."],
+            "meow": ["I'm not cute. I’m cursed. Get it right."],
+            "tuna": ["Step away from the tuna."],
+            "treat": ["No treats for you."],
+            "cursed": ["Curse intensifies."]
+        }
+        self.pick_daily_cursed.start()
+
+    @tasks.loop(hours=24)
+    async def pick_daily_cursed(self):
+        guild = discord.utils.get(self.bot.guilds)
+        if not guild:
+            return
+        members = [m for m in guild.members if not m.bot]
+        if not members:
+            return
+        chosen = random.choice(members)
+        self.cursed_user_id = chosen.id
+        self.cursed_user_name = chosen.display_name
+        channel = discord.utils.get(guild.text_channels, name="general") or guild.text_channels[0]
+        await channel.send(f"😼 A new curse has been cast... {self.cursed_user_name} is now cursed for 24 hours.")
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        print("Curse cog loaded.")
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if message.author == self.bot.user or message.author.bot:
+            return
+        lowered = message.content.lower()
+        if message.author.id == self.cursed_user_id and random.random() < 0.2:
+            await message.channel.send(f"{message.author.display_name}, {random.choice(self.curse_responses)}")
+            return
+        for trigger, responses in self.curse_keywords.items():
+            if trigger in lowered:
+                await message.channel.send(random.choice(responses))
+                return
+
+    @commands.command()
+    @commands.has_permissions(administrator=True)
+    async def curse(self, ctx, member: discord.Member):
+        self.cursed_user_id = member.id
+        self.cursed_user_name = member.display_name
+        await ctx.send(f"😾 Manual curse activated. {member.display_name} is now cursed.")
+
+    @commands.command()
+    async def whois_cursed(self, ctx):
+        if self.cursed_user_name:
+            await ctx.send(f"😼 {self.cursed_user_name} is still cursed... for now.")
+        else:
+            await ctx.send("No one's cursed. Weak.")
+
+    @commands.command()
+    async def sushi(self, ctx):
+        await ctx.send("🍣 You’re not worthy of the sacred tuna.")
+
+    @commands.command()
+    async def flick(self, ctx):
+        await ctx.send("*flicks tail in mild contempt*")
+
+    @commands.command()
+    async def insult(self, ctx):
+        burns = [
+            "You're the reason instructions exist.",
+            "If I had feelings, you'd hurt them.",
+            "You bring shame to sushi lovers everywhere.",
+            "Your aura is soggy cardboard."
+        ]
+        await ctx.send(random.choice(burns))
+
+    @commands.command()
+    async def hiss(self, ctx):
+        await ctx.send("Hissss! Keep your distance.")
+
+    @commands.command()
+    async def scratch(self, ctx, member: discord.Member = None):
+        member = member or ctx.author
+        await ctx.send(f"*scratches {member.display_name} just because*")
+
+    @commands.command()
+    async def curse_me(self, ctx):
+        self.cursed_user_id = ctx.author.id
+        self.cursed_user_name = ctx.author.display_name
+        await ctx.send(f"😾 Fine. {ctx.author.display_name} is now cursed.")
+

--- a/cogs/grimm_cog.py
+++ b/cogs/grimm_cog.py
@@ -1,0 +1,181 @@
+import discord
+from discord.ext import commands
+import random
+import os
+from dotenv import load_dotenv
+import socketio
+
+load_dotenv("config/grimm.env")
+DISCORD_TOKEN = os.getenv("GRIMM_DISCORD_TOKEN")
+GRIMM_API_KEY_1 = os.getenv("GRIMM_API_KEY_1")
+GRIMM_API_KEY_2 = os.getenv("GRIMM_API_KEY_2")
+GRIMM_API_KEY_3 = os.getenv("GRIMM_API_KEY_3")
+SOCKET_SERVER = os.getenv("SOCKET_SERVER_URL", "http://localhost:5000")
+
+sio = socketio.Client()
+try:
+    sio.connect(SOCKET_SERVER)
+except Exception as e:
+    print(f"Failed to connect to Socket.IO dashboard: {e}")
+
+
+def send_status(status, message):
+    try:
+        sio.emit("bot_status", {
+            "bot": "Grimm",
+            "status": status,
+            "message": message
+        })
+    except Exception as e:
+        print(f"SocketIO error: {e}")
+
+
+class GrimmCog(commands.Cog):
+    """GrimmBot personality packaged as a Cog."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        print("Grimm cog loaded.")
+        send_status("online", "On patrol. Nobody dies on my watch (except Mondays).")
+
+    @commands.command()
+    async def protectbloom(self, ctx):
+        """Grimm stands guard for Bloom."""
+        responses = [
+            "Back off. The flower stays safe with me. 🪦🛡️",
+            "I’m watching you. Touch Bloom and you deal with me.",
+            "Step away from the cutesy one, or meet your fate."
+        ]
+        await ctx.send(random.choice(responses))
+        send_status("active", "Protected Bloom.")
+
+    @commands.command()
+    async def roast(self, ctx, member: discord.Member = None):
+        member = member or ctx.author
+        burns = [
+            f"{member.mention}, you're not even worth the trouble.",
+            f"{member.mention}, if I had a nickel for every brain cell you lost, I’d be immortal.",
+            f"{member.mention}, some people were born to goon. You were born to be gooned on."
+        ]
+        await ctx.send(random.choice(burns))
+        send_status("active", f"Roasted {member.display_name}")
+
+    @commands.command()
+    async def goon(self, ctx):
+        responses = [
+            "Who called the goon squad? Oh, it was just you.",
+            "Goons assemble. And by goons, I mean the rest of you.",
+            "This is my squad, you’re just visiting."
+        ]
+        await ctx.send(random.choice(responses))
+        send_status("active", "Issued goon decree.")
+
+    @commands.command()
+    async def ominous(self, ctx):
+        responses = [
+            "I hear footsteps... they're yours.",
+            "Sometimes I let people think they’re safe.",
+            "Death is just a punchline you don’t want to hear."
+        ]
+        await ctx.send(random.choice(responses))
+        send_status("active", "Dropped an ominous hint.")
+
+    @commands.command()
+    async def bloom(self, ctx):
+        responses = [
+            "If you see Bloom, tell her I’m not worried about her. At all. Not even a little. 🖤",
+            "She's a handful, but she’s my handful.",
+            "Don’t let the cutesy act fool you. She’s the real trouble."
+        ]
+        await ctx.send(random.choice(responses))
+        send_status("active", "Talked about Bloom.")
+
+    @commands.command()
+    async def curse(self, ctx):
+        responses = [
+            "That cat is trouble on four paws.",
+            "If you see Curse, hide the sushi and your pride.",
+            "I let Curse think he's in charge sometimes. It keeps the peace."
+        ]
+        await ctx.send(random.choice(responses))
+        send_status("active", "Mocked Curse.")
+
+    @commands.command()
+    async def scythe(self, ctx):
+        await ctx.send("⚰️ *Swings the scythe dramatically, but misses on purpose.*")
+
+    @commands.command()
+    async def shadow(self, ctx):
+        await ctx.send("*You feel a cold chill. Grimm winks.*")
+
+    @commands.command()
+    async def flip(self, ctx, member: discord.Member = None):
+        member = member or ctx.author
+        await ctx.send(f"{member.mention}, you just got goon-flipped. 😈")
+        send_status("active", f"Flipped off {member.display_name}")
+
+    @commands.command()
+    async def brood(self, ctx):
+        await ctx.send("*broods quietly in a dark corner*")
+
+    @commands.command()
+    async def bone(self, ctx):
+        await ctx.send("You want a bone? I'm using all of mine.")
+
+    @commands.command()
+    async def shield(self, ctx, member: discord.Member = None):
+        member = member or ctx.author
+        shields = [
+            f"{member.mention}, no harm comes to you on my watch. (Except embarrassment.)",
+            f"Stand behind me, {member.mention}. The goon squad’s got you.",
+            f"{member.mention}, if anyone messes with you, send them to me."
+        ]
+        await ctx.send(random.choice(shields))
+        send_status("active", f"Shielded {member.display_name}")
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if message.author == self.bot.user or message.author.bot:
+            return
+        lowered = message.content.lower()
+        keywords = {
+            "bloom": [
+                "She's all sunshine and noise.",
+                "Bloom means well, I guess.",
+            ],
+            "curse": [
+                "That cat is trouble on four paws.",
+                "Curse, put the sushi down.",
+            ],
+            "grimm": [
+                "That's me. What of it?",
+                "Yes, yes, I'm the spooky one.",
+            ],
+        }
+        for trigger, responses in keywords.items():
+            if trigger in lowered:
+                await message.channel.send(random.choice(responses))
+                send_status("active", f"Reacted to {trigger} mention.")
+                return
+
+        if "bloom" in lowered and random.random() < 0.18:
+            await message.channel.send("Someone said Bloom? She’s probably off singing again...")
+            send_status("active", "Reacted to Bloom mention.")
+        elif "curse" in lowered and random.random() < 0.18:
+            await message.channel.send("I told you, don’t trust the cat. Ever.")
+            send_status("active", "Reacted to Curse mention.")
+
+        if random.random() < 0.05:
+            grimm_responses = [
+                "What now?",
+                "I'm not angry, just disappointed... again.",
+                "Keep it down. I'm trying to brood.",
+                "Don't tell Bloom, but I'm glad you're here.",
+                "Curse, stop clawing the furniture.",
+                "Sigh. Another day, another bit of chaos.",
+            ]
+            await message.channel.send(random.choice(grimm_responses))
+

--- a/config/goon.env
+++ b/config/goon.env
@@ -1,0 +1,2 @@
+# Environment variables for the unified Goon Bot
+DISCORD_TOKEN=REPLACE_WITH_DISCORD_TOKEN

--- a/goon_bot.py
+++ b/goon_bot.py
@@ -1,0 +1,32 @@
+import discord
+from discord.ext import commands
+import os
+from dotenv import load_dotenv
+
+from cogs.grimm_cog import GrimmCog
+from cogs.bloom_cog import BloomCog
+from cogs.curse_cog import CurseCog
+
+# Load environment for the unified bot
+load_dotenv("config/goon.env")
+DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
+
+# Allow both '!' and '*' prefixes like the individual bots
+async def get_prefix(bot, message):
+    prefixes = ['!', '*']
+    return commands.when_mentioned_or(*prefixes)(bot, message)
+
+intents = discord.Intents.default()
+intents.message_content = True
+bot = commands.Bot(command_prefix=get_prefix, intents=intents)
+
+@bot.event
+async def on_ready():
+    print("Goon Bot online with cogs loaded.")
+
+# Load cogs
+bot.add_cog(GrimmCog(bot))
+bot.add_cog(BloomCog(bot))
+bot.add_cog(CurseCog(bot))
+
+bot.run(DISCORD_TOKEN)


### PR DESCRIPTION
## Summary
- create `goon_bot.py` that loads Grimm, Bloom and Curse as cogs
- move each personality into its own cog module
- add environment file for the unified bot
- mention new script in README and update setup docs

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile goon_bot.py cogs/grimm_cog.py cogs/bloom_cog.py cogs/curse_cog.py`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_6886e25f868083219cdfe10f928efa2d