### PR TITLE
Add dynamic cog loading and admin commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Grimmbot is a small collection of Discord bots that make up the "Goon Squad":
 Grimm, Bloom and Curse. Each bot lives in its own Python file and has a
 slightly different personality. The project is intentionally lightweight so you
 can run one bot or all three depending on your needs. A new optional script
-`goon_bot.py` allows loading every personality as modular cogs, inspired by the
-Red Discord Bot style of customization.
+`goon_bot.py` automatically loads every personality from the `cogs/` folder and
+includes an Admin cog for dynamically loading/unloading modules at runtime.
+This mirrors the modular approach used by Red Discord Bot.
 
 ## Repository layout
 
@@ -107,6 +108,7 @@ The script `project_generator.sh` was once used to create prototype code inside
 if you want to experiment with additional personalities.
 
 For a modular approach similar to the Red Discord Bot, check out
-`goon_bot.py`. It loads each personality as a cog so you can enable or disable
-them as you like.
+`goon_bot.py`. It now scans the `cogs/` directory on startup and loads every
+extension it finds. You can enable or disable cogs at runtime with the Admin
+commands (`load`, `unload`, `reload`, and `listcogs`).
 

--- a/cogs/admin_cog.py
+++ b/cogs/admin_cog.py
@@ -1,0 +1,51 @@
+import os
+import glob
+from discord.ext import commands
+
+class AdminCog(commands.Cog):
+    """Administration utilities for managing cogs."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command()
+    @commands.is_owner()
+    async def load(self, ctx, cog: str):
+        """Load a cog by its module name."""
+        ext = f"cogs.{cog}"
+        try:
+            await self.bot.load_extension(ext)
+            await ctx.send(f"Loaded {ext}")
+        except Exception as e:
+            await ctx.send(f"Failed to load {ext}: {e}")
+
+    @commands.command()
+    @commands.is_owner()
+    async def unload(self, ctx, cog: str):
+        """Unload a cog."""
+        ext = f"cogs.{cog}"
+        try:
+            await self.bot.unload_extension(ext)
+            await ctx.send(f"Unloaded {ext}")
+        except Exception as e:
+            await ctx.send(f"Failed to unload {ext}: {e}")
+
+    @commands.command()
+    @commands.is_owner()
+    async def reload(self, ctx, cog: str):
+        """Reload a cog."""
+        ext = f"cogs.{cog}"
+        try:
+            await self.bot.reload_extension(ext)
+            await ctx.send(f"Reloaded {ext}")
+        except Exception as e:
+            await ctx.send(f"Failed to reload {ext}: {e}")
+
+    @commands.command(name="listcogs")
+    @commands.is_owner()
+    async def list_cogs(self, ctx):
+        """List loaded cogs."""
+        await ctx.send("Cogs loaded: " + ", ".join(self.bot.extensions.keys()))
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(AdminCog(bot))

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -145,3 +145,8 @@ class BloomCog(commands.Cog):
         ]
         await ctx.send(random.choice(compliments))
 
+
+async def setup(bot: commands.Bot):
+    """Load the cog."""
+    await bot.add_cog(BloomCog(bot))
+

--- a/cogs/curse_cog.py
+++ b/cogs/curse_cog.py
@@ -118,3 +118,8 @@ class CurseCog(commands.Cog):
         self.cursed_user_name = ctx.author.display_name
         await ctx.send(f"😾 Fine. {ctx.author.display_name} is now cursed.")
 
+
+async def setup(bot: commands.Bot):
+    """Load the cog."""
+    await bot.add_cog(CurseCog(bot))
+

--- a/cogs/grimm_cog.py
+++ b/cogs/grimm_cog.py
@@ -179,3 +179,7 @@ class GrimmCog(commands.Cog):
             ]
             await message.channel.send(random.choice(grimm_responses))
 
+
+async def setup(bot: commands.Bot):
+    """Load the cog."""
+    await bot.add_cog(GrimmCog(bot))

--- a/goon_bot.py
+++ b/goon_bot.py
@@ -1,11 +1,9 @@
+import asyncio
+import os
+import glob
 import discord
 from discord.ext import commands
-import os
 from dotenv import load_dotenv
-
-from cogs.grimm_cog import GrimmCog
-from cogs.bloom_cog import BloomCog
-from cogs.curse_cog import CurseCog
 
 # Load environment for the unified bot
 load_dotenv("config/goon.env")
@@ -24,9 +22,15 @@ bot = commands.Bot(command_prefix=get_prefix, intents=intents)
 async def on_ready():
     print("Goon Bot online with cogs loaded.")
 
-# Load cogs
-bot.add_cog(GrimmCog(bot))
-bot.add_cog(BloomCog(bot))
-bot.add_cog(CurseCog(bot))
+async def load_startup_cogs():
+    for file in glob.glob("cogs/*_cog.py"):
+        ext = f"cogs.{os.path.splitext(os.path.basename(file))[0]}"
+        try:
+            await bot.load_extension(ext)
+            print(f"Loaded {ext}")
+        except Exception as e:
+            print(f"Failed to load {ext}: {e}")
+
+asyncio.run(load_startup_cogs())
 
 bot.run(DISCORD_TOKEN)


### PR DESCRIPTION
## Summary
- add AdminCog with commands for loading, unloading, and reloading cogs
- modify goon_bot to scan the `cogs/` directory and load extensions on startup
- provide `setup` entry points in existing cogs for extension loading
- document new modular behaviour in README

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e54af75c832189e7353a7eed2434