### PR TITLE
Add unified env template

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ robots can be developed on their own branches and merged back once stable.
    - `config/goon.env`
 
    Each file defines variables named like `GRIMM_DISCORD_TOKEN` or
-   `BLOOM_API_KEY_1`. The example values show what to set.
+   `BLOOM_API_KEY_1`. The example values show what to set. A consolidated
+   template listing **all** variables is available at
+   `config/env_template.env` to make setup easier.
 
 ## Running the bots
 

--- a/config/env_template.env
+++ b/config/env_template.env
@@ -1,0 +1,24 @@
+# Example unified environment variables for all Goon Squad bots.
+# Copy this file to .env or into the files under config/ and fill in your values.
+
+# GrimmBot settings
+GRIMM_DISCORD_TOKEN=
+GRIMM_API_KEY_1=
+GRIMM_API_KEY_2=
+GRIMM_API_KEY_3=
+SOCKET_SERVER_URL=
+
+# BloomBot settings
+BLOOM_DISCORD_TOKEN=
+BLOOM_API_KEY_1=
+BLOOM_API_KEY_2=
+BLOOM_API_KEY_3=
+
+# CurseBot settings
+CURSE_DISCORD_TOKEN=
+CURSE_API_KEY_1=
+CURSE_API_KEY_2=
+CURSE_API_KEY_3=
+
+# Unified bot settings
+DISCORD_TOKEN=


### PR DESCRIPTION
## Summary
- document environment variables in one spot
- reference new template in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886f64dd0048321824dd7175ab2b4e0