### PR TITLE
Add periodic server announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,22 @@ For a modular approach similar to the Red Discord Bot, check out
 extension it finds. You can enable or disable cogs at runtime with the Admin
 commands (`load`, `unload`, `reload`, and `listcogs`).
 
+
+## Example server layout
+
+These bots were designed with the following Discord server structure in mind.
+
+### Roles
+- Server booster
+- Goons
+- Goonets
+- Royalty
+
+### Categories and channels
+- **Intake**: `#new-here`
+- **Gen pop**: `#non-gooning`, `#gooning`
+- **Yapping**: `yapper's anonymous` (voice)
+- **Royalty**: `#me-n-bea`, `the-baby-yap` (voice)
+
+An `AnnouncementCog` periodically posts reminders in `#gooning` and provides a
+`serverinfo` command that lists this layout in chat.

--- a/cogs/announcement_cog.py
+++ b/cogs/announcement_cog.py
@@ -1,0 +1,46 @@
+import discord
+from discord.ext import commands, tasks
+
+# Server reference information for quick access
+SERVER_ROLES = [
+    "Server booster",
+    "Goons",
+    "Goonets",
+    "Royalty",
+]
+
+SERVER_CATEGORIES = {
+    "Intake": ["new-here"],
+    "Gen pop": ["non-gooning", "gooning"],
+    "Yapping": ["yapper's anonymous (voice)"],
+    "Royalty": ["me-n-bea", "the-baby-yap (voice)"],
+}
+
+class AnnouncementCog(commands.Cog):
+    """Send periodic announcements and list server layout."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.announcement_loop.start()
+
+    @tasks.loop(hours=12)
+    async def announcement_loop(self):
+        guild = discord.utils.get(self.bot.guilds)
+        if not guild:
+            return
+        channel = discord.utils.get(guild.text_channels, name="gooning")
+        if channel:
+            await channel.send(
+                "Stay chaotic, Goons and Goonets! Check #non-gooning for chill chats."
+            )
+
+    @commands.command(name="serverinfo")
+    async def server_info(self, ctx):
+        """Display configured server roles and categories."""
+        role_list = ", ".join(SERVER_ROLES)
+        category_lines = [f"{cat}: {', '.join(chs)}" for cat, chs in SERVER_CATEGORIES.items()]
+        categories = "\n".join(category_lines)
+        await ctx.send(f"**Roles**: {role_list}\n**Categories**:\n{categories}")
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(AnnouncementCog(bot))


### PR DESCRIPTION
## Summary
- create `AnnouncementCog` to send periodic reminders and show server layout
- document example server roles and categories in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6886fdb9ad588321a24e3dc955937c76