### PR TITLE
Add ChatGPT integration cog

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ robots can be developed on their own branches and merged back once stable.
 3. Fill in the single environment file found in `config/setup.env` with your
    Discord tokens and any API keys the bots rely on. A template is provided at
    `config/env_template.env` listing variables for every bot so you only have to
-   edit one place.
+   edit one place. Set `OPENAI_API_KEY` if you want ChatGPT-powered replies.
 
 ## Running the bots
 
@@ -108,6 +108,7 @@ Commands use the `*` prefix:
 - `clear` – remove a handful of recent messages.
 - `play <url>` – stream music from YouTube into a voice channel.
 - `stop` – stop music and disconnect from voice.
+- `chat <prompt>` – ask ChatGPT a question and get an in-character reply.
 
 ## Developing your own bots
 

--- a/cogs/gpt_cog.py
+++ b/cogs/gpt_cog.py
@@ -1,0 +1,60 @@
+import os
+import openai
+from discord.ext import commands
+from dotenv import load_dotenv
+
+load_dotenv("config/setup.env")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+openai.api_key = OPENAI_API_KEY
+
+SYSTEM_MESSAGES = {
+    "Grimm": "You are Grimm, a grumpy but caring skeleton leader. Keep replies short, sarcastic and protective.",
+    "Bloom": "You are Bloom, an energetic reaper with a love of musicals and hugs. Speak with lots of enthusiasm and emojis!",
+    "Curse": "You are Curse, a mischievous cat. Respond with playful snark and cat-like behavior.",
+}
+
+class GPTCog(commands.Cog):
+    """Cog that adds a ChatGPT-based chat command and mention replies."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    def _system_prompt(self) -> str:
+        name = self.bot.user.name if self.bot.user else "GoonBot"
+        return SYSTEM_MESSAGES.get(name, f"You are {name}, a helpful member of the Goon Squad.")
+
+    async def _chatgpt(self, prompt: str) -> str:
+        if not OPENAI_API_KEY:
+            return "OpenAI API key not configured."
+        try:
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {"role": "system", "content": self._system_prompt()},
+                    {"role": "user", "content": prompt},
+                ],
+                max_tokens=150,
+                temperature=0.8,
+            )
+            return response.choices[0].message.content.strip()
+        except Exception:
+            return "Sorry, I couldn't reach ChatGPT."
+
+    @commands.command(name="chat")
+    async def chat(self, ctx, *, prompt: str):
+        """Chat with the bot using ChatGPT."""
+        reply = await self._chatgpt(prompt)
+        await ctx.send(reply)
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if message.author.bot or self.bot.user not in message.mentions:
+            return
+        prompt = message.content.replace(self.bot.user.mention, "").strip()
+        if not prompt:
+            return
+        reply = await self._chatgpt(prompt)
+        await message.channel.send(reply)
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(GPTCog(bot))

--- a/config/env_template.env
+++ b/config/env_template.env
@@ -22,3 +22,4 @@ CURSE_API_KEY_3=
 
 # Unified bot settings
 DISCORD_TOKEN=
+OPENAI_API_KEY=

--- a/config/setup.env
+++ b/config/setup.env
@@ -22,3 +22,4 @@ CURSE_API_KEY_3=
 
 # Unified bot settings
 DISCORD_TOKEN=
+OPENAI_API_KEY=


### PR DESCRIPTION
## Summary
- add GPTCog for ChatGPT-powered replies
- add `OPENAI_API_KEY` variable to environment templates
- document ChatGPT in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886fe95fc748321b9e2138042fd683d