### PR TITLE
Add karaoke command to BloomBot

### DIFF
--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -144,6 +144,20 @@ async def sing(ctx):
     await ctx.send("*bursts into a Broadway solo* 🎙️✨")
 
 @bot.command()
+async def karaoke(ctx, *, song: str | None = None):
+    """Start a mini karaoke moment."""
+    lines = [
+        "Don’t stop believin’!",
+        "Let it gooooooo!",
+        "Mamma mia, here I go again!",
+        "Just a small-town girl, living in a lonely world…",
+    ]
+    if song:
+        await ctx.send(f"🎤 Singing **{song}** together!")
+    else:
+        await ctx.send(random.choice(lines) + " 🎶")
+
+@bot.command()
 async def grimm(ctx):
     await ctx.send("He’s my favorite spooky grump. Show him some love!")
 

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -90,6 +90,20 @@ class BloomCog(commands.Cog):
         await ctx.send("*bursts into a Broadway solo* 🎙️✨")
 
     @commands.command()
+    async def karaoke(self, ctx, *, song: str | None = None):
+        """Start a mini karaoke moment."""
+        lines = [
+            "Don’t stop believin’!",
+            "Let it gooooooo!",
+            "Mamma mia, here I go again!",
+            "Just a small-town girl, living in a lonely world…",
+        ]
+        if song:
+            await ctx.send(f"🎤 Singing **{song}** together!")
+        else:
+            await ctx.send(random.choice(lines) + " 🎶")
+
+    @commands.command()
     async def grimm(self, ctx):
         await ctx.send("He’s my favorite spooky grump. Show him some love!")
 


### PR DESCRIPTION
## Summary
- implement a `karaoke` command in `bloom_bot.py`
- support the same command in `BloomCog`

## Testing
- `python -m py_compile bloom_bot.py cogs/bloom_cog.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688700f649188321849d9aa23ab0c76e