### PR TITLE
Improve setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,16 @@ robots can be developed on their own branches and merged back once stable.
 
    Alternatively you can run `./setup.sh` which installs the same
    dependencies for you.
-3. Fill in the single environment file found in `config/setup.env` with your
-   Discord tokens and any API keys the bots rely on. A template is provided at
-   `config/env_template.env` listing variables for every bot so you only have to
-   edit one place. Set `OPENAI_API_KEY` if you want ChatGPT-powered replies.
+3. Create the environment file used by every bot:
+
+   ```bash
+   cp config/env_template.env config/setup.env
+   ```
+
+   Open `config/setup.env` and fill in your Discord tokens and API keys. This
+   single file is shared across all bots so you only have to edit it once. Set
+   `OPENAI_API_KEY` if you want ChatGPT-powered replies. See
+   [`config/README.md`](config/README.md) for details.
 
 ## Running the bots
 

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,20 @@
+# Configuration Guide
+
+All bots read their tokens and API keys from a single file: `config/setup.env`.
+Keeping everything in one place makes it easy to manage credentials.
+
+## Creating `setup.env`
+
+1. Copy the template file:
+
+   ```bash
+   cp config/env_template.env config/setup.env
+   ```
+
+2. Open `config/setup.env` in your editor and fill in each value.
+   The sections are grouped by bot (Grimm, Bloom, Curse) followed by the
+   shared settings. Set `OPENAI_API_KEY` if you want ChatGPT features.
+
+3. Save the file. When you run any bot, it automatically loads these values.
+
+Do **not** commit `setup.env` to version control. It should remain private.


### PR DESCRIPTION
## Summary
- centralize environment configuration instructions
- update README step to copy env template and link to config guide

## Testing
- `python -m py_compile grimm_bot.py bloom_bot.py curse_bot.py goon_bot.py media_player.py`
- `python -m py_compile cogs/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688701e7784083219f3c3bfec068559f