### PR TITLE
Add playful commands

### DIFF
--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -158,6 +158,28 @@ class BloomCog(commands.Cog):
         ]
         await ctx.send(random.choice(compliments))
 
+    @commands.command()
+    async def dance(self, ctx):
+        """Start a random dance party."""
+        moves = ["Cha-cha-cha!", "Time to boogie!", "Let's breakdance!"]
+        await ctx.send(random.choice(moves) + " 💃")
+
+    @commands.command()
+    async def sunshine(self, ctx):
+        """Shower the chat with sunshine."""
+        quotes = [
+            "Sunshine, lollipops, and rainbows!",
+            "You're my little ray of light!",
+            "Let's chase the clouds away!",
+        ]
+        await ctx.send(random.choice(quotes))
+
+    @commands.command()
+    async def flower(self, ctx):
+        """Share a virtual flower."""
+        flowers = ["🌸", "🌺", "🌷", "🌻", "💮"]
+        await ctx.send(random.choice(flowers) + " for you!")
+
 
 async def setup(bot: commands.Bot):
     """Load the cog."""

--- a/cogs/curse_cog.py
+++ b/cogs/curse_cog.py
@@ -118,6 +118,22 @@ class CurseCog(commands.Cog):
         self.cursed_user_name = ctx.author.display_name
         await ctx.send(f"😾 Fine. {ctx.author.display_name} is now cursed.")
 
+    @commands.command()
+    async def hairball(self, ctx):
+        """Share a lovely hairball."""
+        await ctx.send("*coughs up a hairball on your shoes*")
+
+    @commands.command()
+    async def pounce(self, ctx, member: discord.Member | None = None):
+        """Pounce on someone."""
+        member = member or ctx.author
+        await ctx.send(f"*pounces on {member.display_name} unexpectedly*")
+
+    @commands.command()
+    async def nap(self, ctx):
+        """Announce that Curse is taking a nap."""
+        await ctx.send("😼 Curling up for a nap. Don't bother me.")
+
 
 async def setup(bot: commands.Bot):
     """Load the cog."""

--- a/cogs/grimm_cog.py
+++ b/cogs/grimm_cog.py
@@ -126,6 +126,24 @@ class GrimmCog(commands.Cog):
         await ctx.send("You want a bone? I'm using all of mine.")
 
     @commands.command()
+    async def doom(self, ctx):
+        """Announce an ominous countdown to doom."""
+        hours = random.randint(1, 24)
+        await ctx.send(f"Doom arrives in {hours} hours. Or not. We'll see.")
+
+    @commands.command()
+    async def guard(self, ctx, member: discord.Member | None = None):
+        """Grimm stands guard for the specified member."""
+        member = member or ctx.author
+        await ctx.send(f"Standing guard for {member.display_name}. Nothing gets past me.")
+
+    @commands.command()
+    async def haunt(self, ctx, member: discord.Member | None = None):
+        """Playfully haunt a user."""
+        member = member or ctx.author
+        await ctx.send(f"*haunts {member.display_name} for fun*")
+
+    @commands.command()
     async def shield(self, ctx, member: discord.Member = None):
         member = member or ctx.author
         shields = [


### PR DESCRIPTION
## Summary
- extend grimm cog with `doom`, `guard`, and `haunt` commands
- add `dance`, `sunshine`, and `flower` commands for bloom cog
- expand curse cog with `hairball`, `pounce`, and `nap` commands

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68870319eb7c8321af3b59a810710c75