### PR TITLE
Add queen command to Bloom

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Commands use the `*` prefix:
 - `*boba` – talk about bubble tea.
 - `*compliment` – send a random compliment.
 - `*boy` – share a playful boy-themed line.
+- `*queen` – share a playful "yas queen" line.
 
 ### CurseBot
 - `!curse @user` – manually curse a user (admin only).

--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -130,6 +130,35 @@ boy_lines = [
     "Boys, let's conquer the day with joy!"
 ]
 
+# === Bloom Queen Lines ===
+queen_lines = [
+    "Yas queen! Slay the day!",
+    "Queens, keep those crowns high!",
+    "Hey girl, you're unstoppable!",
+    "Yas queen, your sparkle is unmatched!",
+    "Girls just wanna have fun and rule!",
+    "Queen vibes only, let's shine!",
+    "You go girl, absolutely iconic!",
+    "Yaaaas queen, keep shining bright!",
+    "Girls, let's conquer with kindness!",
+    "Queen energy incoming! 💖",
+    "Slay it, queen! You got this!",
+    "Hey queen, want some boba?",
+    "Queens unite for a dance party!",
+    "Yas, girls! Let's make magic happen!",
+    "Queen, your confidence is contagious!",
+    "Girls, keep being amazing!",
+    "Yas queen, the world is yours!",
+    "Queen power! Nothing can stop us!",
+    "Hey queens, time to sparkle!",
+    "Girls rule, everyone else drools!",
+    "Yas queen, show off that style!",
+    "Queen squad, assemble!",
+    "Keep that crown polished, girl!",
+    "Queens, let's turn up the glitter!",
+    "You're royalty, girl—don't forget it!",
+]
+
 # === Keyword Triggers ===
 keywords = {
     "grimm": [
@@ -156,6 +185,9 @@ keywords = {
         "You're shining brighter than my glitter!",
         "Compliments inbound: you're amazing!"
     ],
+    "queen": queen_lines,
+    "girl": queen_lines,
+    "girls": queen_lines,
     "boy": boy_lines,
     "boys": boy_lines,
     "squad": [
@@ -275,6 +307,11 @@ async def compliment(ctx):
 async def boy(ctx):
     """Share a playful boy-themed line."""
     await ctx.send(random.choice(boy_lines))
+
+@bot.command()
+async def queen(ctx):
+    """Share a playful yas queen-style line."""
+    await ctx.send(random.choice(queen_lines))
 
 bot.run(DISCORD_TOKEN)
 

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -87,6 +87,33 @@ class BloomCog(commands.Cog):
             "Hey boy, keep being amazing!",
             "Boys, let's conquer the day with joy!"
         ]
+        self.queen_lines = [
+            "Yas queen! Slay the day!",
+            "Queens, keep those crowns high!",
+            "Hey girl, you're unstoppable!",
+            "Yas queen, your sparkle is unmatched!",
+            "Girls just wanna have fun and rule!",
+            "Queen vibes only, let's shine!",
+            "You go girl, absolutely iconic!",
+            "Yaaaas queen, keep shining bright!",
+            "Girls, let's conquer with kindness!",
+            "Queen energy incoming! 💖",
+            "Slay it, queen! You got this!",
+            "Hey queen, want some boba?",
+            "Queens unite for a dance party!",
+            "Yas, girls! Let's make magic happen!",
+            "Queen, your confidence is contagious!",
+            "Girls, keep being amazing!",
+            "Yas queen, the world is yours!",
+            "Queen power! Nothing can stop us!",
+            "Hey queens, time to sparkle!",
+            "Girls rule, everyone else drools!",
+            "Yas queen, show off that style!",
+            "Queen squad, assemble!",
+            "Keep that crown polished, girl!",
+            "Queens, let's turn up the glitter!",
+            "You're royalty, girl—don't forget it!",
+        ]
         self.keywords = {
             "grimm": [
                 "Grimm is my spooky bestie.",
@@ -112,6 +139,9 @@ class BloomCog(commands.Cog):
                 "You're shining brighter than my glitter!",
                 "Compliments inbound: you're amazing!"
             ],
+            "queen": self.queen_lines,
+            "girl": self.queen_lines,
+            "girls": self.queen_lines,
             "boy": self.boy_lines,
             "boys": self.boy_lines,
             "squad": [
@@ -217,6 +247,11 @@ class BloomCog(commands.Cog):
     async def boy(self, ctx):
         """Share a playful boy-themed line."""
         await ctx.send(random.choice(self.boy_lines))
+
+    @commands.command()
+    async def queen(self, ctx):
+        """Share a playful yas queen-style line."""
+        await ctx.send(random.choice(self.queen_lines))
 
     @commands.command()
     async def dance(self, ctx):


### PR DESCRIPTION
## Summary
- add playful "yas queen" lines to Bloom
- respond to queen-themed keywords
- implement `*queen` command
- document the new Bloom command

## Testing
- `python3 -m py_compile bloom_bot.py cogs/bloom_cog.py`
- `flake8 .` *(fails: E501 line too long and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688708341cfc8321b95b750e70afd981