### PR TITLE
Streamlined setup instructions

### DIFF
--- a/INSTALL_SETUP.txt
+++ b/INSTALL_SETUP.txt
@@ -1,0 +1,11 @@
+Goon Squad Bots Quick Install
+=============================
+
+1. Install Python 3.8 or newer.
+2. Run `pip install -r requirements.txt` (or execute `./setup.sh`).
+3. Copy `config/env_template.env` to `config/setup.env` and edit your tokens and API keys.
+4. Start any bot:
+   - `python grimm_bot.py`
+   - `python bloom_bot.py`
+   - `python curse_bot.py`
+   - `python goon_bot.py`

--- a/README.md
+++ b/README.md
@@ -27,30 +27,21 @@ This mirrors the modular approach used by Red Discord Bot.
 The `main` branch contains the latest working bots. New ideas or additional
 robots can be developed on their own branches and merged back once stable.
 
-## Setup
+## Quick setup
 
-1. Ensure Python 3.8 or higher is installed.
-2. Install the required packages:
-
- ```bash
- pip install -r requirements.txt
- ```
-
-  The package list now includes `yt_dlp` for YouTube playback and
-  `lavalink` for media query parsing.
-
-   Alternatively you can run `./setup.sh` which installs the same
-   dependencies for you.
-3. Create the environment file used by every bot:
+1. Install Python 3.8 or newer.
+2. Install the required packages with `pip install -r requirements.txt`.
+   You can also run `./setup.sh` which performs the same step for you.
+3. Copy the example configuration and edit it once for all bots:
 
    ```bash
    cp config/env_template.env config/setup.env
+   $EDITOR config/setup.env  # fill in tokens and API keys
    ```
 
-   Open `config/setup.env` and fill in your Discord tokens and API keys. This
-   single file is shared across all bots so you only have to edit it once. Set
-   `OPENAI_API_KEY` if you want ChatGPT-powered replies. See
-   [`config/README.md`](config/README.md) for details.
+   This single file stores every Discord token and API key. Set
+   `OPENAI_API_KEY` if you want ChatGPT powered features. See
+   [`config/README.md`](config/README.md) for a line-by-line explanation.
 
 ## Running the bots
 

--- a/config/README.md
+++ b/config/README.md
@@ -1,7 +1,8 @@
 # Configuration Guide
 
-All bots read their tokens and API keys from a single file: `config/setup.env`.
-Keeping everything in one place makes it easy to manage credentials.
+All bots read their tokens and API keys from a single file:
+`config/setup.env`. Keeping everything in one place makes it easy to manage
+credentials and avoids duplicating values across multiple files.
 
 ## Creating `setup.env`
 
@@ -11,10 +12,10 @@ Keeping everything in one place makes it easy to manage credentials.
    cp config/env_template.env config/setup.env
    ```
 
-2. Open `config/setup.env` in your editor and fill in each value.
-   The sections are grouped by bot (Grimm, Bloom, Curse) followed by the
-   shared settings. Set `OPENAI_API_KEY` if you want ChatGPT features.
+2. Open `config/setup.env` in your editor and fill in each value. The sections
+   are grouped by bot (Grimm, Bloom, Curse) followed by shared settings. Set
+   `OPENAI_API_KEY` if you want ChatGPT features.
 
-3. Save the file. When you run any bot, it automatically loads these values.
+3. Save the file. When you run any bot it automatically loads these values.
 
 Do **not** commit `setup.env` to version control. It should remain private.


### PR DESCRIPTION
## Summary
- rewrite README setup section for clarity
- tweak configuration README
- add `INSTALL_SETUP.txt` quick-start guide

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68870de6ef188321955ef3aab54c39bf