### PR TITLE
Add Curse pet command

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Commands use the `*` prefix:
 - `!insult` – deliver an insult.
 - `!hiss` – hiss at the server.
 - `!scratch [@user]` – scratch someone just because.
+- `!pet` – attempt to pet Curse (may end badly).
 - `!curse_me` – willingly take the curse.
 
 ### Additional cogs

--- a/cogs/curse_cog.py
+++ b/cogs/curse_cog.py
@@ -115,6 +115,32 @@ class CurseCog(commands.Cog):
         await ctx.send(f"*scratches {member.display_name} just because*")
 
     @commands.command()
+    async def pet(self, ctx):
+        """Attempt to pet Curse."""
+        if random.random() < 0.5:
+            await ctx.send("😼 *purrs softly* Maybe I'll spare you... for now.")
+        else:
+            await ctx.send(
+                f"*scratches {ctx.author.display_name} and hisses.* You're cursed now!"
+            )
+            self.cursed_user_id = ctx.author.id
+            self.cursed_user_name = ctx.author.display_name
+            try:
+                await ctx.author.edit(nick=f"Cursed {ctx.author.display_name}")
+            except discord.Forbidden:
+                pass
+            guild = ctx.guild
+            role = discord.utils.get(guild.roles, name="Cursed")
+            if role is None:
+                role = await guild.create_role(
+                    name="Cursed", colour=discord.Colour.purple()
+                )
+            try:
+                await ctx.author.add_roles(role)
+            except discord.Forbidden:
+                pass
+
+    @commands.command()
     async def curse_me(self, ctx):
         self.cursed_user_id = ctx.author.id
         self.cursed_user_name = ctx.author.display_name

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -256,6 +256,34 @@ async def scratch(ctx, member: discord.Member = None):
 
 
 @bot.command()
+async def pet(ctx):
+    """Attempt to pet Curse."""
+    global cursed_user_id, cursed_user_name
+    if random.random() < 0.5:
+        await ctx.send("😼 *purrs softly* Maybe I'll spare you... for now.")
+    else:
+        await ctx.send(
+            f"*scratches {ctx.author.display_name} and hisses.* You're cursed now!"
+        )
+        cursed_user_id = ctx.author.id
+        cursed_user_name = ctx.author.display_name
+        try:
+            await ctx.author.edit(nick=f"Cursed {ctx.author.display_name}")
+        except discord.Forbidden:
+            pass
+        guild = ctx.guild
+        role = discord.utils.get(guild.roles, name="Cursed")
+        if role is None:
+            role = await guild.create_role(
+                name="Cursed", colour=discord.Colour.purple()
+            )
+        try:
+            await ctx.author.add_roles(role)
+        except discord.Forbidden:
+            pass
+
+
+@bot.command()
 async def curse_me(ctx):
     global cursed_user_id, cursed_user_name
     cursed_user_id = ctx.author.id


### PR DESCRIPTION
## Summary
- add `!pet` command to curse bot and cog
- grant cursed role & nickname if curse scratches you
- document new command in README

## Testing
- `python -m py_compile curse_bot.py cogs/curse_cog.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68870f610bc48321a5059a5cd870aed6