### PR TITLE
Add nickname command

### DIFF
--- a/cogs/grimm_cog.py
+++ b/cogs/grimm_cog.py
@@ -119,6 +119,25 @@ class GrimmCog(commands.Cog):
         send_status("active", f"Flipped off {member.display_name}")
 
     @commands.command()
+    async def nickname(self, ctx, member: discord.Member = None):
+        """Playfully call someone a grumpy nickname."""
+        member = member or ctx.author
+        names = [
+            "Bone-for-brains",
+            "Lopsided bonehead",
+            "Spineless clank",
+            "Gloomy goon",
+            "Dusty dingbat",
+            "Clattering fool",
+            "Creaky numbskull",
+            "Rattle-boned scatterbrain",
+            "Moldy misfit",
+            "Walking pile of leftovers",
+        ]
+        await ctx.send(f"{member.mention}, you're a {random.choice(names)}.")
+        send_status("active", f"Called {member.display_name} a nickname")
+
+    @commands.command()
     async def brood(self, ctx):
         await ctx.send("*broods quietly in a dark corner*")
 

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -256,6 +256,25 @@ async def flip(ctx, member: discord.Member = None):
     await ctx.send(f"{member.mention}, you just got goon-flipped. 😈")
     send_status("active", f"Flipped off {member.display_name}")
 
+@bot.command()
+async def nickname(ctx, member: discord.Member = None):
+    """Playfully call someone a grumpy nickname."""
+    member = member or ctx.author
+    names = [
+        "Bone-for-brains",
+        "Lopsided bonehead",
+        "Spineless clank",
+        "Gloomy goon",
+        "Dusty dingbat",
+        "Clattering fool",
+        "Creaky numbskull",
+        "Rattle-boned scatterbrain",
+        "Moldy misfit",
+        "Walking pile of leftovers",
+    ]
+    await ctx.send(f"{member.mention}, you're a {random.choice(names)}.")
+    send_status("active", f"Called {member.display_name} a nickname")
+
 # === BROODING & BONES ===
 
 


### PR DESCRIPTION
## Summary
- add a `nickname` command to GrimmBot scripts
- allows Grimm to hurl playful nicknames at a member

## Testing
- `python -m py_compile grimm_bot.py cogs/grimm_cog.py`


------
https://chatgpt.com/codex/tasks/task_e_6887110db8a4832189733f04d2fa51c5