### PR TITLE
Fix env loading for cogs

### DIFF
--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -3,7 +3,8 @@ import random
 import os
 from dotenv import load_dotenv
 
-load_dotenv("config/bloom.env")
+# Load a single shared configuration file for all bots
+load_dotenv("config/setup.env")
 DISCORD_TOKEN = os.getenv("BLOOM_DISCORD_TOKEN")
 BLOOM_API_KEY_1 = os.getenv("BLOOM_API_KEY_1")
 BLOOM_API_KEY_2 = os.getenv("BLOOM_API_KEY_2")

--- a/cogs/curse_cog.py
+++ b/cogs/curse_cog.py
@@ -4,7 +4,8 @@ import random
 import os
 from dotenv import load_dotenv
 
-load_dotenv("config/curse.env")
+# Load a single shared configuration file for all bots
+load_dotenv("config/setup.env")
 DISCORD_TOKEN = os.getenv("CURSE_DISCORD_TOKEN")
 CURSE_API_KEY_1 = os.getenv("CURSE_API_KEY_1")
 CURSE_API_KEY_2 = os.getenv("CURSE_API_KEY_2")

--- a/cogs/grimm_cog.py
+++ b/cogs/grimm_cog.py
@@ -5,7 +5,8 @@ import os
 from dotenv import load_dotenv
 import socketio
 
-load_dotenv("config/grimm.env")
+# Load a single shared configuration file for all bots
+load_dotenv("config/setup.env")
 DISCORD_TOKEN = os.getenv("GRIMM_DISCORD_TOKEN")
 GRIMM_API_KEY_1 = os.getenv("GRIMM_API_KEY_1")
 GRIMM_API_KEY_2 = os.getenv("GRIMM_API_KEY_2")


### PR DESCRIPTION
## Summary
- ensure cogs load `config/setup.env` instead of their own env files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688712e592a08321938dfd57528aa637