### PR TITLE
Improve setup convenience

### DIFF
--- a/INSTALL_SETUP.txt
+++ b/INSTALL_SETUP.txt
@@ -2,10 +2,12 @@ Goon Squad Bots Quick Install
 =============================
 
 1. Install Python 3.8 or newer.
-2. Run `pip install -r requirements.txt` (or execute `./setup.sh`).
-3. Copy `config/env_template.env` to `config/setup.env` and edit your tokens and API keys.
-4. Start any bot:
-   - `python grimm_bot.py`
-   - `python bloom_bot.py`
-   - `python curse_bot.py`
-   - `python goon_bot.py`
+2. Run the setup helper to install packages and create `config/setup.env` if needed:
+    `./setup.sh`
+3. Edit `config/setup.env` with your tokens and API keys.
+4. Start any bot (or pass its name to `./setup.sh` to launch immediately):
+    - `python grimm_bot.py`
+    - `python bloom_bot.py`
+    - `python curse_bot.py`
+    - `python goon_bot.py`
+    - `./setup.sh goon`

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ robots can be developed on their own branches and merged back once stable.
 ## Quick setup
 
 1. Install Python 3.8 or newer.
-2. Install the required packages with `pip install -r requirements.txt`.
-   You can also run `./setup.sh` which performs the same step for you.
-3. Copy the example configuration and edit it once for all bots:
+2. Run the helper script which installs everything and prepares a config file:
 
    ```bash
-   cp config/env_template.env config/setup.env
-   $EDITOR config/setup.env  # fill in tokens and API keys
+   ./setup.sh
    ```
+
+3. Open `config/setup.env` and fill in your Discord tokens and API keys. The
+   setup script creates this file for you if it doesn't already exist.
 
    This single file stores every Discord token and API key. Set
    `OPENAI_API_KEY` if you want ChatGPT powered features. See
@@ -45,13 +45,14 @@ robots can be developed on their own branches and merged back once stable.
 ## Running the bots
 
 Each bot is completely independent. As long as `config/setup.env` is populated
-with your credentials you can launch any bot directly:
+with your credentials you can launch any bot directly or via the setup script:
 
 ```bash
 python grimm_bot.py   # uses ! commands
 python bloom_bot.py   # uses * commands
 python curse_bot.py   # uses ! commands
 python goon_bot.py    # loads all personalities with both prefixes
+./setup.sh goon       # install & launch in one step
 ```
 
 GrimmBot optionally reports its status to a Socket.IO dashboard if

--- a/setup.sh
+++ b/setup.sh
@@ -25,3 +25,28 @@ echo "Setup complete. Run bots with:"
 echo "  $PY grimm_bot.py"
 echo "  $PY bloom_bot.py"
 echo "  $PY curse_bot.py"
+echo "  $PY goon_bot.py"
+
+# optionally start a bot immediately when passed as an argument
+if [ $# -gt 0 ]; then
+    case "$1" in
+        grimm)
+            exec $PY grimm_bot.py
+            ;;
+        bloom)
+            exec $PY bloom_bot.py
+            ;;
+        curse)
+            exec $PY curse_bot.py
+            ;;
+        goon)
+            exec $PY goon_bot.py
+            ;;
+        *)
+            echo "Unknown bot: $1"
+            echo "Valid options are grimm, bloom, curse, or goon."
+            ;;
+    esac
+else
+    echo "Run './setup.sh <bot>' to launch one immediately."
+fi


### PR DESCRIPTION
## Summary
- add optional bot launcher to `setup.sh`
- simplify setup steps in the README and INSTALL_SETUP
- document one-step boot command

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68871575fcd8832189303670af828ba1