### PR TITLE
Use absolute path for shared setup.env

### DIFF
--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -15,9 +15,11 @@ from discord.ext import commands
 import random
 import os
 from dotenv import load_dotenv
+from pathlib import Path
 
 # Load a single shared configuration file for all bots
-load_dotenv("config/setup.env")
+ENV_PATH = Path(__file__).resolve().parent / "config" / "setup.env"
+load_dotenv(ENV_PATH)
 DISCORD_TOKEN = os.getenv("BLOOM_DISCORD_TOKEN")
 BLOOM_API_KEY_1 = os.getenv("BLOOM_API_KEY_1")
 BLOOM_API_KEY_2 = os.getenv("BLOOM_API_KEY_2")

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -2,9 +2,11 @@ from discord.ext import commands
 import random
 import os
 from dotenv import load_dotenv
+from pathlib import Path
 
 # Load a single shared configuration file for all bots
-load_dotenv("config/setup.env")
+ENV_PATH = Path(__file__).resolve().parents[1] / "config" / "setup.env"
+load_dotenv(ENV_PATH)
 DISCORD_TOKEN = os.getenv("BLOOM_DISCORD_TOKEN")
 BLOOM_API_KEY_1 = os.getenv("BLOOM_API_KEY_1")
 BLOOM_API_KEY_2 = os.getenv("BLOOM_API_KEY_2")

--- a/cogs/curse_cog.py
+++ b/cogs/curse_cog.py
@@ -3,9 +3,11 @@ from discord.ext import commands, tasks
 import random
 import os
 from dotenv import load_dotenv
+from pathlib import Path
 
 # Load a single shared configuration file for all bots
-load_dotenv("config/setup.env")
+ENV_PATH = Path(__file__).resolve().parents[1] / "config" / "setup.env"
+load_dotenv(ENV_PATH)
 DISCORD_TOKEN = os.getenv("CURSE_DISCORD_TOKEN")
 CURSE_API_KEY_1 = os.getenv("CURSE_API_KEY_1")
 CURSE_API_KEY_2 = os.getenv("CURSE_API_KEY_2")

--- a/cogs/gpt_cog.py
+++ b/cogs/gpt_cog.py
@@ -2,8 +2,10 @@ import os
 import openai
 from discord.ext import commands
 from dotenv import load_dotenv
+from pathlib import Path
 
-load_dotenv("config/setup.env")
+ENV_PATH = Path(__file__).resolve().parents[1] / "config" / "setup.env"
+load_dotenv(ENV_PATH)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 openai.api_key = OPENAI_API_KEY
 

--- a/cogs/grimm_cog.py
+++ b/cogs/grimm_cog.py
@@ -3,10 +3,12 @@ from discord.ext import commands
 import random
 import os
 from dotenv import load_dotenv
+from pathlib import Path
 import socketio
 
 # Load a single shared configuration file for all bots
-load_dotenv("config/setup.env")
+ENV_PATH = Path(__file__).resolve().parents[1] / "config" / "setup.env"
+load_dotenv(ENV_PATH)
 DISCORD_TOKEN = os.getenv("GRIMM_DISCORD_TOKEN")
 GRIMM_API_KEY_1 = os.getenv("GRIMM_API_KEY_1")
 GRIMM_API_KEY_2 = os.getenv("GRIMM_API_KEY_2")

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -14,9 +14,11 @@ from discord.ext import commands, tasks
 import random
 import os
 from dotenv import load_dotenv
+from pathlib import Path
 
 # Load a single shared configuration file for all bots
-load_dotenv("config/setup.env")
+ENV_PATH = Path(__file__).resolve().parent / "config" / "setup.env"
+load_dotenv(ENV_PATH)
 DISCORD_TOKEN = os.getenv("CURSE_DISCORD_TOKEN")
 CURSE_API_KEY_1 = os.getenv("CURSE_API_KEY_1")
 CURSE_API_KEY_2 = os.getenv("CURSE_API_KEY_2")

--- a/goon_bot.py
+++ b/goon_bot.py
@@ -4,9 +4,11 @@ import glob
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv
+from pathlib import Path
 
 # Load a single shared configuration file for all bots
-load_dotenv("config/setup.env")
+ENV_PATH = Path(__file__).resolve().parent / "config" / "setup.env"
+load_dotenv(ENV_PATH)
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 
 # Allow both '!' and '*' prefixes like the individual bots

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -15,12 +15,14 @@ from discord.ext import commands
 import os
 
 from dotenv import load_dotenv
+from pathlib import Path
 import random
 import socketio
 
 # === ENVIRONMENT VARIABLES ===
 # Load a single shared configuration file for all bots
-load_dotenv("config/setup.env")
+ENV_PATH = Path(__file__).resolve().parent / "config" / "setup.env"
+load_dotenv(ENV_PATH)
 DISCORD_TOKEN = os.getenv("GRIMM_DISCORD_TOKEN")
 GRIMM_API_KEY_1 = os.getenv("GRIMM_API_KEY_1")
 GRIMM_API_KEY_2 = os.getenv("GRIMM_API_KEY_2")


### PR DESCRIPTION
## Summary
- load `config/setup.env` using `Path` so bots work from any working directory

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68871a5e87148321aa60b2e14b4651f5