### PR TITLE
Update docs for clearer install steps

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,7 +1,7 @@
 Goon Squad Bots - Installation Guide
 ====================================
 
-This guide explains how to install and run the bots from a terminal. Each step notes which folders you will modify.
+This guide explains how to install and run the bots from a terminal. Each step notes which folders you will modify. Windows users should see `INSTALL_WINDOWS.txt` for a platform-specific walkthrough.
 
 Quick install
 -------------

--- a/INSTALL_WINDOWS.txt
+++ b/INSTALL_WINDOWS.txt
@@ -3,7 +3,7 @@ Goon Squad Bots - Windows Installation Guide
 
 This guide walks through installing and launching the bots on Windows using a
 terminal (Command Prompt, PowerShell or Git Bash). Each step notes which
-folders you will modify.
+folders you will modify. Linux and macOS users should refer to `INSTALL.txt`.
 
 1. **Install Python**
    - Download and install Python 3.8 or newer from <https://www.python.org>. Make

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This mirrors the modular approach used by Red Discord Bot.
 - `cogs/music_cog.py` – Stream audio from YouTube links.
 - `cogs/fun_cog.py` – Quick games like dice rolls and an 8‑ball.
 - `media_player.py` – Helpers for parsing media queries and local files.
+- `INSTALL.txt` – step-by-step setup instructions for Linux/macOS.
+- `INSTALL_WINDOWS.txt` – Windows-specific installation guide.
 
 The `main` branch contains the latest working bots. New ideas or additional
 robots can be developed on their own branches and merged back once stable.
@@ -29,7 +31,8 @@ robots can be developed on their own branches and merged back once stable.
 ## Quick setup
 
 1. Install Python 3.8 or newer.
-2. Run the helper script which installs everything and prepares a config file:
+2. Run the helper script to install dependencies from `requirements.txt` and
+   create `config/setup.env` if it doesn't exist:
 
    ```bash
    ./setup.sh
@@ -40,7 +43,11 @@ robots can be developed on their own branches and merged back once stable.
 
    This single file stores every Discord token and API key. Set
    `OPENAI_API_KEY` if you want ChatGPT powered features. See
-   [`config/README.md`](config/README.md) for a line-by-line explanation.
+
+   [`config/README.md`](config/README.md) provides a line-by-line explanation.
+
+For a step-by-step installation guide see [`INSTALL.txt`](INSTALL.txt). Windows
+users should follow [`INSTALL_WINDOWS.txt`](INSTALL_WINDOWS.txt).
 
 ## Running the bots
 

--- a/config/README.md
+++ b/config/README.md
@@ -19,3 +19,6 @@ credentials and avoids duplicating values across multiple files.
 3. Save the file. When you run any bot it automatically loads these values.
 
 Do **not** commit `setup.env` to version control. It should remain private.
+
+Refer to [`../INSTALL.txt`](../INSTALL.txt) for instructions on installing the
+required Python packages.


### PR DESCRIPTION
## Summary
- mention INSTALL.txt and INSTALL_WINDOWS.txt in repo layout
- clarify what the setup helper does
- link to platform specific install guides
- cross-reference install guides in config docs

## Testing
- `codespell -q 3 README.md INSTALL.txt INSTALL_WINDOWS.txt config/README.md`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6887911541f48321aafd4f7d740d6fb0