### PR TITLE
Improve token error handling

### DIFF
--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -339,4 +339,6 @@ async def queen(ctx):
     """Share a playful yas queen-style line."""
     await ctx.send(random.choice(queen_lines))
 
+if not DISCORD_TOKEN:
+    raise RuntimeError("BLOOM_DISCORD_TOKEN not set in config/setup.env")
 bot.run(DISCORD_TOKEN)

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -292,4 +292,6 @@ async def curse_me(ctx):
     cursed_user_name = ctx.author.display_name
     await ctx.send(f"😾 Fine. {ctx.author.display_name} is now cursed.")
 
+if not DISCORD_TOKEN:
+    raise RuntimeError("CURSE_DISCORD_TOKEN not set in config/setup.env")
 bot.run(DISCORD_TOKEN)

--- a/goon_bot.py
+++ b/goon_bot.py
@@ -39,4 +39,6 @@ async def load_startup_cogs():
 
 asyncio.run(load_startup_cogs())
 
+if not DISCORD_TOKEN:
+    raise RuntimeError("DISCORD_TOKEN not set in config/setup.env")
 bot.run(DISCORD_TOKEN)

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -336,4 +336,6 @@ async def on_message(message):
     await bot.process_commands(message)
 
 # === RUN THE BOT ===
+if not DISCORD_TOKEN:
+    raise RuntimeError("GRIMM_DISCORD_TOKEN not set in config/setup.env")
 bot.run(DISCORD_TOKEN)


### PR DESCRIPTION
## Summary
- raise a clear error when each bot's Discord token is missing

## Testing
- `flake8`
- `python -m py_compile *.py cogs/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879eb924c48321ad6c79dc0345e7b2