### PR TITLE
Add ChatGPT command to cyberpunk campaign

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Commands use the `*` prefix:
 - `cyberstart` – begin a cyberpunk themed DnD campaign.
 - `cyberfight` – fight one of the bots with evolving difficulty.
 - `cyberstatus` – view your campaign record.
+- `cyberchat <prompt>` – talk to the campaign's narrator and characters via ChatGPT.
 
 ## Developing your own bots
 


### PR DESCRIPTION
## Summary
- integrate OpenAI client in the cyberpunk campaign cog
- add `cyberchat` command for narrative ChatGPT responses
- document new command in README

## Testing
- `python -m py_compile cogs/cyberpunk_campaign_cog.py`
- `python -m py_compile cogs/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6887a1a7ce0883219a6748130c7f32c8