### PR TITLE
Fix trivia cog and add new command

### DIFF
--- a/cogs/trivia_cog.py
+++ b/cogs/trivia_cog.py
@@ -34,6 +34,17 @@ class TriviaCog(commands.Cog):
             else:
                 await ctx.send(f"Nope! The answer was **{qa['answer']}**.")
 
+    @commands.command(name="addtrivia")
+    @commands.is_owner()
+    async def add_trivia(self, ctx, *, qa: str):
+        """Add a new trivia question. Use `question | answer` format."""
+        if "|" not in qa:
+            await ctx.send("Format should be: question | answer")
+            return
+        question, answer = [part.strip() for part in qa.split("|", 1)]
+        self.questions.append({"question": question, "answer": answer.lower()})
+        await ctx.send("Trivia question added.")
+
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(TriviaCog(bot))


### PR DESCRIPTION
## Summary
- add ability for owners to extend trivia question list

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887a6cfa4dc8321b950365648f9bbf5