### PR TITLE
Add interactive setup

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -8,7 +8,8 @@ Quick install
 1. Install Python 3.8 or newer.
 2. Run the setup helper to install packages and create `config/setup.env` if needed:
    `./setup.sh`
-3. Edit `config/setup.env` with your tokens and API keys.
+3. Run the interactive configuration helper to supply your tokens and API keys:
+   `python configure.py`
 4. Start any bot (or pass its name to `./setup.sh` to launch immediately):
    - `python grimm_bot.py`
    - `python bloom_bot.py`
@@ -53,11 +54,11 @@ Detailed steps
      cp config/env_template.env config/setup.env
      ```
      (On Windows you can use `copy` instead of `cp`.)
-   - Edit `config/setup.env` in a text editor:
+   - You can fill in credentials interactively by running:
      ```
-     notepad config/setup.env
+     python configure.py
      ```
-     Fill in your Discord tokens and any API keys. Example entries:
+     This script updates `config/setup.env` for you. Example entries include:
      ```
      GRIMM_DISCORD_TOKEN=your_grimm_token_here
      BLOOM_DISCORD_TOKEN=your_bloom_token_here

--- a/README.md
+++ b/README.md
@@ -41,11 +41,16 @@ robots can be developed on their own branches and merged back once stable.
    ./setup.sh
    ```
 
-3. Open `config/setup.env` and fill in your Discord tokens and API keys. The
-   setup script creates this file for you if it doesn't already exist.
+3. Run the interactive configuration tool to fill in your Discord tokens and
+   API keys:
 
-   This single file stores every Discord token and API key. Set
-   `OPENAI_API_KEY` if you want ChatGPT powered features. See
+   ```bash
+   python configure.py
+   ```
+
+   This writes your details to `config/setup.env`. You can rerun the script at
+   any time to update values. Set `OPENAI_API_KEY` if you want ChatGPT powered
+   features. See
 
    [`config/README.md`](config/README.md) provides a line-by-line explanation.
 

--- a/configure.py
+++ b/configure.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Interactive configuration helper for the Goon Squad bots."""
+from pathlib import Path
+
+TEMPLATE_PATH = Path("config/env_template.env")
+SETUP_PATH = Path("config/setup.env")
+
+
+def read_existing(path: Path) -> dict:
+    data = {}
+    if path.exists():
+        for line in path.read_text().splitlines():
+            if not line.strip() or line.lstrip().startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            data[key.strip()] = value.strip()
+    return data
+
+
+def main() -> None:
+    print("== Goon Squad Interactive Setup ==\n")
+    TEMPLATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    existing = read_existing(SETUP_PATH)
+    lines = []
+    for line in TEMPLATE_PATH.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in line:
+            lines.append(line)
+            continue
+        key = line.split("=", 1)[0]
+        default = existing.get(key, "")
+        prompt = f"{key} [{default}]: " if default else f"{key}: "
+        value = input(prompt).strip() or default
+        lines.append(f"{key}={value}")
+    SETUP_PATH.write_text("\n".join(lines) + "\n")
+    print(f"\nSaved configuration to {SETUP_PATH}\n")
+    print("Next steps:")
+    print("  1. Ensure Python 3.8+ is installed.")
+    print("  2. Install dependencies: python -m pip install -r requirements/base.txt")
+    print("  3. Run a bot, e.g.: python goon_bot.py\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `configure.py` for editing `config/setup.env` through an interactive CLI
- document the new tool in **INSTALL.txt** and **README.md**

## Testing
- `python -m py_compile configure.py`


------
https://chatgpt.com/codex/tasks/task_e_6887b4471128832195c3b898601bb930