### PR TITLE
Add bootstrap installer and doc updates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,17 +4,15 @@ This single document covers Windows, macOS and Linux.
 
 ## Quick setup
 1. Install Python 3.8 or newer.
-2. Clone this repository:
+2. Run the bootstrap script directly from your terminal:
    ```bash
-   git clone https://github.com/The-w0rst/grimmbot.git
-   cd grimmbot
+   bash <(curl -L https://raw.githubusercontent.com/The-w0rst/grimmbot/main/bootstrap.sh)
    ```
-3. From a terminal, run:
-   ```bash
-   python install.py
-   ```
-   On Windows you may prefer `py -3 install.py`.
-   The installer installs dependencies and creates `config/setup.env`.
+   This clones the repository, installs dependencies and launches the
+   interactive installer. On Windows you may prefer `py -3 install.py`
+   after cloning manually.
+3. When prompted, enter your Discord tokens and any API keys. A file
+   `config/setup.env` will be created.
 4. Launch a bot:
    ```bash
    python grimm_bot.py   # or bloom_bot.py, curse_bot.py, goon_bot.py

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ This mirrors the modular approach used by Red Discord Bot.
 - `curse_bot.py` – CurseBot, a mischievous calico (command prefix `!`).
 - `goon_bot.py` – Unified bot that loads all personalities as cogs.
 - `config/setup.env` – Environment variables for all bots in one place.
-- `requirements.txt` – Python package requirements.
+- `requirements/base.txt` – Python package requirements used by the installer.
+- `bootstrap.sh` – One-line installer for cloning and running the setup.
 - `install.py` – Interactive installer for dependencies and config.
 - `setup.sh` – Optional helper script for installing dependencies.
 - `cogs/trivia_cog.py` – Simple trivia mini‑game.
@@ -34,7 +35,15 @@ robots can be developed on their own branches and merged back once stable.
 
 ## Installation
 
-Follow these steps to get a bot running.
+The fastest method is to run the bootstrap script directly from your
+terminal. It downloads the repository, installs dependencies and then
+launches the interactive configuration:
+
+```bash
+bash <(curl -L https://raw.githubusercontent.com/The-w0rst/grimmbot/main/bootstrap.sh)
+```
+
+Alternatively follow the manual steps below.
 
 1. Install **Python 3.8** or newer.
 2. Clone this repository and change into the project directory.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Quick install script for Grimmbot
+set -e
+
+REPO_URL="https://github.com/The-w0rst/grimmbot.git"
+TARGET_DIR="grimmbot"
+
+# Clone repository unless we're already inside it
+if [ ! -d .git ] || [ ! -f install.py ]; then
+    if [ ! -d "$TARGET_DIR" ]; then
+        echo "Cloning repository..."
+        git clone "$REPO_URL" "$TARGET_DIR"
+    fi
+    cd "$TARGET_DIR"
+fi
+
+# Determine Python executable
+if command -v python3 >/dev/null 2>&1; then
+    PY=python3
+else
+    PY=python
+fi
+
+# Run interactive installer
+$PY install.py
+


### PR DESCRIPTION
## Summary
- add `bootstrap.sh` for one-line installation
- document bootstrap usage in `README.md` and `INSTALL.md`
- clarify requirements file location

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6887c1c1bb008321add628b9e4e05f7c