### PR TITLE
Assign unique prefix for CurseBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Here's what you'll find lurking in the repo:
 
 - `grimm_bot.py` – Grimm is our cranky skeleton (prefix `!`).
 - `bloom_bot.py` – Bloom brings bubbly chaos (prefix `*`).
-- `curse_bot.py` – that's me, the mischievous calico (prefix `!`).
+- `curse_bot.py` – that's me, the mischievous calico (prefix `?`).
 - `goon_bot.py` – pulls us all together as cogs.
 - `config/setup.env` – one file to hold all the secret tokens.
 - `requirements/base.txt` – packages the installer grabs.
@@ -109,15 +109,15 @@ Commands use the `*` prefix:
 - `*queen` – share a playful "yas queen" line.
 
 ### CurseBot
-- `!curse @user` – manually curse a user (admin only).
-- `!whois_cursed` – check the currently cursed user.
-- `!sushi` – mention sushi.
-- `!flick` – flick the tail.
-- `!insult` – deliver an insult.
-- `!hiss` – hiss at the server.
-- `!scratch [@user]` – scratch someone just because.
-- `!pet` – attempt to pet Curse (may end badly).
-- `!curse_me` – willingly take the curse.
+- `?curse @user` – manually curse a user (admin only).
+- `?whois_cursed` – check the currently cursed user.
+- `?sushi` – mention sushi.
+- `?flick` – flick the tail.
+- `?insult` – deliver an insult.
+- `?hiss` – hiss at the server.
+- `?scratch [@user]` – scratch someone just because.
+- `?pet` – attempt to pet Curse (may end badly).
+- `?curse_me` – willingly take the curse.
 
 ### Additional cogs
 - `trivia` – play a quick trivia round.

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -29,7 +29,7 @@ CURSE_API_KEY_3 = os.getenv("CURSE_API_KEY_3")
 
 intents = discord.Intents.default()
 intents.message_content = True
-bot = commands.Bot(command_prefix="!", intents=intents)
+bot = commands.Bot(command_prefix="?", intents=intents)
 
 # === CurseBot Personality ===
 curse_personality = {

--- a/goon_bot.py
+++ b/goon_bot.py
@@ -14,11 +14,11 @@ if not ENV_PATH.exists():
 load_dotenv(ENV_PATH)
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 
-# Allow both '!' and '*' prefixes like the individual bots
+# Allow '!', '*', and '?' prefixes like the individual bots
 
 
 async def get_prefix(bot, message):
-    prefixes = ["!", "*"]
+    prefixes = ["!", "*", "?"]
     return commands.when_mentioned_or(*prefixes)(bot, message)
 
 


### PR DESCRIPTION
## Summary
- switch CurseBot's command prefix to `?`
- allow `?` in goon_bot prefix handler
- document the new prefix throughout README

## Testing
- `python -m py_compile curse_bot.py goon_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6887cbaa640883218a752bca12d95107