### PR TITLE
Add daily gifts and playful commands to CurseBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Commands use the `*` prefix:
 - `?scratch [@user]` – scratch someone just because.
 - `?pet` – attempt to pet Curse (may end badly).
 - `?curse_me` – willingly take the curse.
+- `?hairball` – share a revolting hairball.
+- `?pounce [@user]` – pounce on someone unexpectedly.
+- `?nap` – announce that Curse is taking a nap.
 
 ### Additional cogs
 - `trivia` – play a quick trivia round.

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -77,6 +77,27 @@ async def pick_daily_cursed():
     )
 
 
+@tasks.loop(hours=24)
+async def daily_gift():
+    """Give a random user a random gift from Curse."""
+    guild = discord.utils.get(bot.guilds)
+    if not guild:
+        return
+    members = [m for m in guild.members if not m.bot]
+    if not members:
+        return
+    recipient = random.choice(members)
+    gift = random.choice(gifts)
+    channel = (
+        discord.utils.get(guild.text_channels, name="general") or guild.text_channels[0]
+    )
+    if gift["positive"]:
+        line = random.choice(positive_gift_responses)
+    else:
+        line = random.choice(negative_gift_responses)
+    await channel.send(f"🎁 {recipient.display_name}, " + line.format(gift=gift["name"]))
+
+
 # === Curse Interactions ===
 curse_responses = [
     "You smell like expired sushi. 🤢",
@@ -167,6 +188,72 @@ curse_keywords = {
     "cursed": ["Curse intensifies."],
 }
 
+# Gifts Curse may randomly give users once per day
+gifts = [
+    {"name": "a bucket of fent", "positive": False},
+    {"name": "some fresh sushi", "positive": True},
+    {"name": "a cursed hairball", "positive": False},
+    {"name": "a shiny fish scale", "positive": True},
+    {"name": "a slightly chewed toy mouse", "positive": False},
+    {"name": "a jar of ghost peppers", "positive": False},
+    {"name": "a mysterious paw print", "positive": False},
+    {"name": "a half-empty bottle of catnip", "positive": True},
+    {"name": "a tiny scythe keychain", "positive": True},
+    {"name": "a worn out scratching post", "positive": False},
+    {"name": "a glitter bomb from Bloom", "positive": True},
+    {"name": "a sardine-scented candle", "positive": False},
+    {"name": "a skeleton shaped cookie", "positive": True},
+    {"name": "a bottle of midnight ink", "positive": True},
+    {"name": "a creepy lullaby record", "positive": False},
+    {"name": "a stack of ominous fortunes", "positive": False},
+    {"name": "a black lace collar", "positive": False},
+    {"name": "a box of ancient bones", "positive": False},
+    {"name": "a cracked mirror shard", "positive": False},
+    {"name": "a haunted feather toy", "positive": False},
+    {"name": "a whispering seashell", "positive": True},
+    {"name": "a mysterious potion vial", "positive": False},
+    {"name": "a cursed collar bell", "positive": False},
+    {"name": "a pair of glow-in-the-dark eyes", "positive": True},
+    {"name": "a bag of shadow dust", "positive": False},
+    {"name": "a mini spellbook", "positive": True},
+    {"name": "a jar of swirling mist", "positive": False},
+    {"name": "a spiky chew toy", "positive": True},
+    {"name": "a midnight-blue ribbon", "positive": True},
+    {"name": "a scratched-up diary", "positive": False},
+    {"name": "a sinister plush bat", "positive": True},
+    {"name": "a tattered pirate flag", "positive": False},
+    {"name": "a small potion of mischief", "positive": True},
+    {"name": "a cursed fortune cookie", "positive": False},
+    {"name": "a cracked crystal ball", "positive": False},
+    {"name": "a pinch of phantom fur", "positive": False},
+    {"name": "a haunted treat bag", "positive": False},
+    {"name": "a glow stick stash", "positive": True},
+    {"name": "a vial of spooky slime", "positive": False},
+    {"name": "a lock of spectral hair", "positive": False},
+    {"name": "a weathered treasure map", "positive": True},
+    {"name": "a bowl of strange soup", "positive": False},
+    {"name": "a ball of tangled yarn", "positive": True},
+    {"name": "a rogue lightning bug", "positive": True},
+    {"name": "a packet of dry ice", "positive": False},
+    {"name": "a cat-shaped voodoo doll", "positive": False},
+    {"name": "a cursed sticker pack", "positive": False},
+    {"name": "a gnarled tree branch", "positive": False},
+    {"name": "a bag of sour candy", "positive": True},
+    {"name": "an ominous black envelope", "positive": False},
+]
+
+positive_gift_responses = [
+    "Curse reluctantly gives you {gift}.",
+    "With a sly grin, Curse drops {gift} in your lap.",
+    "Curse acts indifferent but slides you {gift}.",
+]
+
+negative_gift_responses = [
+    "Curse hisses and tosses {gift} at you.",
+    "You get {gift}. Curse smirks wickedly.",
+    "Curse dumps {gift} on you with a laugh.",
+]
+
 # === On Ready ===
 
 
@@ -174,6 +261,7 @@ curse_keywords = {
 async def on_ready():
     print(f"{curse_personality['name']} is here to ruin someone's day.")
     pick_daily_cursed.start()
+    daily_gift.start()
 
 
 # === Passive Comments to Cursed User ===
@@ -303,6 +391,25 @@ async def curse_me(ctx):
     cursed_user_id = ctx.author.id
     cursed_user_name = ctx.author.display_name
     await ctx.send(f"😾 Fine. {ctx.author.display_name} is now cursed.")
+
+
+@bot.command()
+async def hairball(ctx):
+    """Share a lovely hairball."""
+    await ctx.send("*coughs up a hairball on your shoes*")
+
+
+@bot.command()
+async def pounce(ctx, member: discord.Member | None = None):
+    """Pounce on someone."""
+    member = member or ctx.author
+    await ctx.send(f"*pounces on {member.display_name} unexpectedly*")
+
+
+@bot.command()
+async def nap(ctx):
+    """Announce that Curse is taking a nap."""
+    await ctx.send("😼 Curling up for a nap. Don't bother me.")
 
 
 if not DISCORD_TOKEN:


### PR DESCRIPTION
## Summary
- extend CurseBot with a daily gift drop and start it on ready
- add `hairball`, `pounce`, and `nap` commands
- document the new CurseBot commands in README

## Testing
- `python -m py_compile curse_bot.py`
- `python -m py_compile bloom_bot.py grimm_bot.py goon_bot.py cogs/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6887cd1fc7c88321a998af709b86946f