### PR TITLE
Expand Grimm functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Here's a taste of what each bot can do.
 - `!flip [@user]` – flip a user.
 - `!brood` – quietly brood.
 - `!bone` – offer a skeletal joke.
+- `!gloom` – check Grimm's gloom level.
+- `!lament` – hear a gloomy thought.
+- `!bonk [@user]` – bonk someone with a femur.
+- `!inventory` – reveal a random item from Grimm's stash.
 - `!shield [@user]` – provide mock protection.
 
 ### BloomBot

--- a/cogs/grimm_extra_cog.py
+++ b/cogs/grimm_extra_cog.py
@@ -1,0 +1,47 @@
+import discord
+from discord.ext import commands
+import random
+
+from . import grimm_utils
+
+COG_VERSION = "1.0"
+
+
+class GrimmExtraCog(commands.Cog):
+    """Additional utilities and fun commands for Grimm."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command()
+    async def gloom(self, ctx):
+        """Check Grimm's current gloom level."""
+        level = grimm_utils.gloom_level()
+        if level >= 70:
+            mood = "The shadows gather. Grimm is pleased."
+        elif level >= 40:
+            mood = "Decently gloomy. Could be worse."
+        else:
+            mood = "Too bright for Grimm's taste."
+        await ctx.send(f"Gloom level: {level}/100. {mood}")
+
+    @commands.command()
+    async def lament(self, ctx):
+        """Share one of Grimm's gloomy laments."""
+        await ctx.send(grimm_utils.random_lament())
+
+    @commands.command()
+    async def bonk(self, ctx, member: discord.Member | None = None):
+        """Bonk a member with Grimm's trusty femur."""
+        member = member or ctx.author
+        await ctx.send(f"*bonks {member.display_name} on the head with a femur*")
+
+    @commands.command(name="inventory")
+    async def show_inventory(self, ctx):
+        """Display a random item from Grimm's stash."""
+        item = grimm_utils.random_item()
+        await ctx.send(f"Grimm hands you {item}.")
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(GrimmExtraCog(bot))

--- a/docs/cogs_overview.md
+++ b/docs/cogs_overview.md
@@ -10,6 +10,7 @@ what mischief it adds.
 | `bloom_cog.py` | Implements the cheerful Bloom personality as a cog. |
 | `curse_cog.py` | Implements the mischievous Curse personality. |
 | `grimm_cog.py` | Implements the grumpy Grimm personality. |
+| `grimm_extra_cog.py` | Extra utilities for Grimm: gloom meter, laments and bonks. |
 | `fun_cog.py` | Provides quick games like dice rolls, coin flips and an 8‑ball. |
 | `trivia_cog.py` | Simple trivia mini‑game. |
 | `music_cog.py` | Stream audio from YouTube links into voice channels. |

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -16,6 +16,7 @@ from discord.ext import commands
 import os
 
 from dotenv import load_dotenv
+import grimm_utils
 from pathlib import Path
 import random
 import socketio
@@ -303,6 +304,30 @@ async def brood(ctx):
 async def bone(ctx):
     await ctx.send("You want a bone? I'm using all of mine.")
 
+@bot.command()
+async def gloom(ctx):
+    level = grimm_utils.gloom_level()
+    if level >= 70:
+        mood = "The shadows gather. Grimm is pleased."
+    elif level >= 40:
+        mood = "Decently gloomy. Could be worse."
+    else:
+        mood = "Too bright for Grimm's taste."
+    await ctx.send(f"Gloom level: {level}/100. {mood}")
+
+@bot.command()
+async def lament(ctx):
+    await ctx.send(grimm_utils.random_lament())
+
+@bot.command()
+async def bonk(ctx, member: discord.Member = None):
+    member = member or ctx.author
+    await ctx.send(f"*bonks {member.display_name} on the head with a femur*")
+
+@bot.command()
+async def inventory(ctx):
+    item = grimm_utils.random_item()
+    await ctx.send(f"Grimm hands you {item}.")
 
 # === RANDOM PROTECTIVE RESPONSES ===
 

--- a/grimm_utils.py
+++ b/grimm_utils.py
@@ -1,0 +1,38 @@
+import random
+
+
+LAMENTS = [
+    "Another century, another pile of bones.",
+    "I could go for a nice grave nap.",
+    "Why does everyone assume I want to talk?",
+    "Being undead is overrated.",
+    "My scythe gets more respect than I do.",
+]
+
+INVENTORY_ITEMS = [
+    "a cracked hourglass",
+    "a chipped femur",
+    "an old cloak clasp",
+    "a tarnished coin",
+    "a faded wanted poster",
+    "a jar of suspicious dust",
+    "a gloom-infused lantern",
+    "a bundle of wilted roses",
+    "a skull-shaped flask",
+    "a bone polishing kit",
+]
+
+
+def gloom_level() -> int:
+    """Return Grimm's current gloom level from 0 to 100."""
+    return random.randint(0, 100)
+
+
+def random_lament() -> str:
+    """Return a random gloomy lament."""
+    return random.choice(LAMENTS)
+
+
+def random_item() -> str:
+    """Return a random item from Grimm's stash."""
+    return random.choice(INVENTORY_ITEMS)


### PR DESCRIPTION
## Summary
- add `grimm_utils.py` helper module with gloom, laments and items
- create `grimm_extra_cog.py` for extra Grimm commands
- integrate new gloom/lament/bonk/inventory commands in `grimm_bot.py`
- document new commands and cog

## Testing
- `python -m py_compile grimm_bot.py cogs/grimm_extra_cog.py grimm_utils.py`
- `python -m py_compile cogs/*.py`
- `python -m py_compile bloom_bot.py curse_bot.py goon_bot.py grimm_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6887ce7911d48321b81c670a7ced69e7