### PR TITLE
Add glitter chance to Bloom sparkle

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Commands use the `*` prefix:
 - `*grimm` – talk about Grimm.
 - `*curse` – tease Curse.
 - `*cheer` – offer encouragement.
-- `*sparkle` – throw confetti.
+- `*sparkle` – throw confetti (and maybe cover you in glitter).
 - `*drama` – start a musical.
 - `*bloom` – introduce Bloom.
 - `*mood` – display Bloom's mood.

--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -278,6 +278,18 @@ async def cheer(ctx):
 @bot.command()
 async def sparkle(ctx):
     await ctx.send("*throws confetti and joy everywhere* ✨")
+    if random.random() < 0.25:
+        compliment = random.choice(
+            [
+                "You're shining brighter than my glitter!",
+                "Glitter looks good on you!",
+                "You're absolutely dazzling!",
+                "Bloom thinks you're fabulous!",
+            ]
+        )
+        await ctx.send(
+            f"{ctx.author.mention} gets covered in glitter! {compliment}"
+        )
 
 
 @bot.command()

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -252,6 +252,18 @@ class BloomCog(commands.Cog):
     @commands.command()
     async def sparkle(self, ctx):
         await ctx.send("*throws confetti and joy everywhere* ✨")
+        if random.random() < 0.25:
+            compliment = random.choice(
+                [
+                    "You're shining brighter than my glitter!",
+                    "Glitter looks good on you!",
+                    "You're absolutely dazzling!",
+                    "Bloom thinks you're fabulous!",
+                ]
+            )
+            await ctx.send(
+                f"{ctx.author.mention} gets covered in glitter! {compliment}"
+            )
 
     @commands.command()
     async def drama(self, ctx):


### PR DESCRIPTION
## Summary
- update Bloom's sparkle command so there's a 1/4 chance the user gets glittered and complimented
- mirror changes in the old `bloom_bot.py`
- document new effect in `README`

## Testing
- `flake8 cogs/bloom_cog.py bloom_bot.py`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6887d6745ffc83219012af2338d1ff10