### PR TITLE
Fix Python version references

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ Curse here. Let's get these bots running on your machine. This works on
 Windows, macOS, or Linux—take your pick.
 
 ## Quick setup
-1. Install Python 3.8 or newer.
+1. Install Python 3.10 or newer.
 2. Run the bootstrap script:
    ```bash
    bash <(curl -L https://raw.githubusercontent.com/The-w0rst/grimmbot/main/bootstrap.sh)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bash <(curl -L https://raw.githubusercontent.com/The-w0rst/grimmbot/main/bootstr
 
 Prefer manual control? Follow these steps in your terminal:
 
-1. Install **Python 3.8+**.
+1. Install **Python 3.10+**.
 2. Clone the repo and enter the directory:
 
    ```bash

--- a/configure.py
+++ b/configure.py
@@ -38,7 +38,7 @@ def main() -> None:
     SETUP_PATH.write_text("\n".join(lines) + "\n")
     print(f"\nSaved configuration to {SETUP_PATH}\n")
     print("Next steps:")
-    print("  1. Ensure Python 3.8+ is installed.")
+    print("  1. Ensure Python 3.10+ is installed.")
     print("  2. Install dependencies: python -m pip install -r requirements/base.txt")
     print("  3. Run a bot, e.g.: python goon_bot.py\n")
 

--- a/grimbot.md
+++ b/grimbot.md
@@ -5,7 +5,7 @@
 Hey there, mortals. It's **Curse**, your favorite chaotic cat, here to walk you through setting up the whole Grimmbot gang. Follow these steps and you'll have Grimm, Bloom, and me running in no time.
 
 ### Quick Setup
-1. Install Python 3.8 or newer.
+1. Install Python 3.10 or newer.
 2. Run the bootstrap script directly:
    ```bash
    bash <(curl -L https://raw.githubusercontent.com/The-w0rst/grimmbot/main/bootstrap.sh)

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -304,6 +304,7 @@ async def brood(ctx):
 async def bone(ctx):
     await ctx.send("You want a bone? I'm using all of mine.")
 
+
 @bot.command()
 async def gloom(ctx):
     level = grimm_utils.gloom_level()
@@ -315,14 +316,17 @@ async def gloom(ctx):
         mood = "Too bright for Grimm's taste."
     await ctx.send(f"Gloom level: {level}/100. {mood}")
 
+
 @bot.command()
 async def lament(ctx):
     await ctx.send(grimm_utils.random_lament())
+
 
 @bot.command()
 async def bonk(ctx, member: discord.Member = None):
     member = member or ctx.author
     await ctx.send(f"*bonks {member.display_name} on the head with a femur*")
+
 
 @bot.command()
 async def inventory(ctx):

--- a/install.py
+++ b/install.py
@@ -26,8 +26,8 @@ def read_existing(path: Path) -> dict:
 
 def check_python() -> None:
     print("Step 1/4: Checking Python version...")
-    if sys.version_info < (3, 8):
-        sys.exit("Python 3.8 or newer is required. Aborting.")
+    if sys.version_info < (3, 10):
+        sys.exit("Python 3.10 or newer is required. Aborting.")
     print(f"✔ Python {sys.version_info.major}.{sys.version_info.minor} detected.\n")
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def extras_combined(*extra_names):
 
 
 extras_require["dev"] = extras_combined()
-python_requires = ">=3.8"
+python_requires = ">=3.10"
 
 setup(
     name="grimmbot",


### PR DESCRIPTION
## Summary
- fix flake8 issues in `grimm_bot.py`
- update docs and installer for Python 3.10+

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887d95af01083218b15e7e2824b3c83