### PR TITLE
Expand bot responses and clarify installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,6 +36,32 @@ Prefer to get your paws dirty?
    On Windows use `copy` instead of `cp`. Fill in your Discord tokens and API
    keys.
 4. Run `python install.py` to walk through the prompts.
+   The installer guides you through four steps:
+   1. **Python check** – verifies you're running Python 3.10 or newer.
+   2. **Dependencies** – when asked `Install dependencies now? [Y/n]` press
+      Enter to install from `requirements/base.txt` or type `n` to skip.
+   3. **Configuration** – you'll be prompted for each value listed in
+      `config/env_template.env`:
+      - `GRIMM_DISCORD_TOKEN`
+      - `GRIMM_API_KEY_1`
+      - `GRIMM_API_KEY_2`
+      - `GRIMM_API_KEY_3`
+      - `SOCKET_SERVER_URL` *(optional)*
+      - `BLOOM_DISCORD_TOKEN`
+      - `BLOOM_API_KEY_1`
+      - `BLOOM_API_KEY_2`
+      - `BLOOM_API_KEY_3`
+      - `CURSE_DISCORD_TOKEN`
+      - `CURSE_API_KEY_1`
+      - `CURSE_API_KEY_2`
+      - `CURSE_API_KEY_3`
+      - `DISCORD_TOKEN`
+      - `OPENAI_API_KEY`
+      Leave a value blank to keep any existing entry.
+   4. **Choose bot** – finally you'll see a menu:
+      `1. GrimmBot`, `2. BloomBot`, `3. CurseBot`, `4. GoonBot`, `0. Exit`.
+      Enter a number to launch a bot immediately or `0` to finish without
+      starting one.
 5. Launch any bot as shown above. All bots read from `config/setup.env`.
 
 Place optional media files in the `localtracks` directory.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Prefer manual control? Follow these steps in your terminal:
    ```bash
    python install.py
    ```
-   Use `python configure.py` later if you need to update the file.
+   Follow the prompts to install requirements and fill in each token from
+   `config/env_template.env`. Use `python configure.py` later if you need to
+   update the file.
 5. Start any bot you want:
 
    ```bash

--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -79,6 +79,11 @@ bloom_responses = [
     "Pastel power incoming!",
     "Compliment break! You're awesome!",
     "Who needs sleep when we have each other?",
+    "Let's paint the town pastel!",
+    "I'm mailing you a virtual hug right now!",
+    "Any excuse for a dance break, right?",
+    "Glitter makes everything better, trust me!",
+    "Let's turn this chat into a mini musical!",
 ]
 
 # === Bloom Boy Lines ===
@@ -133,6 +138,11 @@ boy_lines = [
     "Boy oh boy, let's throw a party!",
     "Hey boy, keep being amazing!",
     "Boys, let's conquer the day with joy!",
+    "Boy, you're rocking those vibes!",
+    "Boys, more jokes, less worries!",
+    "Boy oh boy, let's level up the fun!",
+    "Boys, let's spam Grimm with selfies!",
+    "Boy, keep shining like the star you are!",
 ]
 
 # === Bloom Queen Lines ===
@@ -162,6 +172,11 @@ queen_lines = [
     "Keep that crown polished, girl!",
     "Queens, let's turn up the glitter!",
     "You're royalty, girl—don't forget it!",
+    "Yas queen, strut your stuff!",
+    "Queens, bring on the sparkle storm!",
+    "Hey girl, your crown looks amazing today!",
+    "Queens rise above the drama!",
+    "Yas queen, keep slaying with kindness!",
 ]
 
 # Lines from Bloom's favorite song "Pretty Little Baby" by Connie Francis
@@ -172,6 +187,11 @@ pretty_little_baby_lines = [
     "Pretty little baby, I'm hoping that you do",
     "Ask your mama, your papa, your sister or your brother",
     "If they've ever loved another like I love you",
+    "Come closer, pretty baby, and whisper softly",
+    "Hold me tight and never let me go",
+    "Pretty little baby, let your love light shine",
+    "Don't you know I'm waiting just for you",
+    "Pretty little baby, I'll always be true",
 ]
 
 # === Keyword Triggers ===
@@ -203,6 +223,11 @@ interactions = [
     "Grimm: Bloom, can you stop with the glitter? No? Okay...",
     "Curse: Hiss. (But like, the friendly kind. Maybe.)",
     "Bloom: Goon Squad! Assemble for hugs!",
+    "Grimm: Bloom, no more musicals during meetings.",
+    "Curse: I'll trade you sushi for silence, Bloom.",
+    "Bloom: Curse, quit shedding on my costumes!",
+    "Grimm: Both of you, behave for five minutes.",
+    "Curse: Only if Bloom stops singing.",
 ]
 
 # === On Ready ===
@@ -271,6 +296,11 @@ async def cheer(ctx):
         "You are doing your best!",
         "Go Goon Squad!",
         "Believe in yourself, or I’ll believe for you!",
+        "You've got this, superstar!",
+        "Every step you take is awesome!",
+        "Smile big, you're amazing!",
+        "Cheering for you from the digital sidelines!",
+        "You're a goon squad legend in the making!",
     ]
     await ctx.send(random.choice(cheers))
 
@@ -329,6 +359,11 @@ async def compliment(ctx):
         "You're the sparkle in my day!",
         "You make the server shine!",
         "I might be a 9 in Drake's book, but I'll be 10 on my birthday.",
+        "You're sweeter than all the bubble tea!",
+        "Your positivity is contagious!",
+        "You glow brighter than neon lights!",
+        "Your creativity inspires me!",
+        "You're the heart of this squad!",
     ]
     await ctx.send(random.choice(compliments))
 

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -175,19 +175,87 @@ curse_responses = [
     "Grimm's scythe is impressive, but my claws are sharper.",
     "Bloom can't stop talking about musicals. Spare me.",
     "One more word and I'll curse your playlist.",
+    "I'd steal your soul, but it looks cheap.",
+    "Grimm snores louder than you talk.",
+    "Bloom's giggle makes my fur stand on end.",
+    "Try me again and I'll curse your coffee.",
+    "I run this squad, the others just pretend.",
 ]
 
 # === Keywords ===
 curse_keywords = {
-    "grimm": ["Oh look, it’s the spooky skeleton again."],
-    "bloom": ["Too much glitter. Not enough chaos."],
-    "sushi": ["BACK OFF. It’s mine."],
-    "pet": ["Touch me and lose a finger."],
-    "curse": ["You rang? Someone's getting hexed."],
-    "meow": ["I'm not cute. I’m cursed. Get it right."],
-    "tuna": ["Step away from the tuna."],
-    "treat": ["No treats for you."],
-    "cursed": ["Curse intensifies."],
+    "grimm": [
+        "Oh look, it’s the spooky skeleton again.",
+        "Grimm, stop rattling around.",
+        "Got bones to pick with me, Grimm?",
+        "The skull king returns.",
+        "Grimm, your scythe is showing.",
+        "Another gloomy comment from Grimm? Shocking.",
+    ],
+    "bloom": [
+        "Too much glitter. Not enough chaos.",
+        "Bloom, take your sunshine elsewhere.",
+        "If Bloom hugs me again, I'm bolting.",
+        "Bloom's energy is exhausting.",
+        "Another musical number, Bloom? Spare me.",
+        "Bloom, you're blinding me with kindness.",
+    ],
+    "sushi": [
+        "BACK OFF. It’s mine.",
+        "Touch my sushi and face my wrath.",
+        "I dream of tuna rolls.",
+        "Sushi is the only good thing in life.",
+        "Hands off my sashimi.",
+        "Did someone say sushi? Mine.",
+    ],
+    "pet": [
+        "Touch me and lose a finger.",
+        "Pet me and face the curse.",
+        "I bite those who pet without asking.",
+        "Petting fee is one tuna roll.",
+        "Petting rights revoked.",
+        "Only Bloom can pet me—maybe.",
+    ],
+    "curse": [
+        "You rang? Someone's getting hexed.",
+        "Another curse request? Fine.",
+        "Curses are on sale today.",
+        "Who wants a fresh hex?",
+        "My curses never miss.",
+        "You can't handle my curses.",
+    ],
+    "meow": [
+        "I'm not cute. I’m cursed. Get it right.",
+        "Did you just meow at me?",
+        "Meow back and I'll hiss.",
+        "I don't meow on command.",
+        "Meowing won't save you.",
+        "Only Bloom gets a purr, maybe.",
+    ],
+    "tuna": [
+        "Step away from the tuna.",
+        "Tuna is my love language.",
+        "I smell tuna. Hand it over.",
+        "No tuna? Then go away.",
+        "Tuna tribute accepted.",
+        "Keep the tuna coming.",
+    ],
+    "treat": [
+        "No treats for you.",
+        "Where are my treats?",
+        "I'll trade insults for treats.",
+        "Treats first, talk later.",
+        "You think you deserve treats? Cute.",
+        "Treats make curses better.",
+    ],
+    "cursed": [
+        "Curse intensifies.",
+        "You're cursed now, congrats.",
+        "Being cursed suits you.",
+        "Another soul joins the cursed ranks.",
+        "Once cursed, always cursed.",
+        "Feel the weight of the curse.",
+    ],
 }
 
 # Gifts Curse may randomly give users once per day
@@ -242,18 +310,33 @@ gifts = [
     {"name": "a gnarled tree branch", "positive": False},
     {"name": "a bag of sour candy", "positive": True},
     {"name": "an ominous black envelope", "positive": False},
+    {"name": "a pawful of loose bolts", "positive": False},
+    {"name": "a spooky origami crane", "positive": True},
+    {"name": "a glow-in-the-dark collar", "positive": True},
+    {"name": "a vial of cursed glitter", "positive": False},
+    {"name": "a tiny haunted painting", "positive": False},
 ]
 
 positive_gift_responses = [
     "Curse reluctantly gives you {gift}.",
     "With a sly grin, Curse drops {gift} in your lap.",
     "Curse acts indifferent but slides you {gift}.",
+    "You receive {gift} while Curse pretends not to care.",
+    "Curse gifts you {gift} and rolls his eyes.",
+    "{gift} appears at your feet courtesy of Curse.",
+    "Enjoy {gift}—don't say I never did anything nice.",
+    "{gift} is tossed your way with a bored flick of the paw.",
 ]
 
 negative_gift_responses = [
     "Curse hisses and tosses {gift} at you.",
     "You get {gift}. Curse smirks wickedly.",
     "Curse dumps {gift} on you with a laugh.",
+    "{gift} hits you square in the face. Thanks, Curse.",
+    "Curse sneers and shoves {gift} into your hands.",
+    "A disgruntled Curse gifts you {gift}. Lucky you.",
+    "{gift}? That's what you deserve, apparently.",
+    "Curse hurls {gift} then walks away snickering.",
 ]
 
 # Responses when the fent cloud knocks out a player
@@ -263,6 +346,11 @@ fent_player_responses = [
     "drops like a rock. Shadow banned for {minutes} minute(s)!",
     "coughs and fades away for {minutes} minute(s).",
     "can't handle the cloud and disappears for {minutes} minute(s).",
+    "is overwhelmed and poofs for {minutes} minute(s).",
+    "gets a face full of fent and dozes off for {minutes} minute(s).",
+    "slinks away, cursed, for {minutes} minute(s).",
+    "vanishes into the mist for {minutes} minute(s).",
+    "is whisked to the shadow realm for {minutes} minute(s).",
 ]
 
 # Responses when a bot gets hit by the fent cloud
@@ -272,6 +360,11 @@ fent_bot_responses = [
     "shrugs off the cloud—perks of undeath.",
     "mumbles that the afterlife smells better than this.",
     "laughs about undead immunity.",
+    "scoffs at your attempt to harm the undead.",
+    "grins—no lungs, no problem.",
+    "continues haunting without pause.",
+    "wonders why you bothered.",
+    "licks the air and declares it spicy.",
 ]
 
 # === On Ready ===
@@ -362,6 +455,11 @@ async def insult(ctx):
         "You're less useful than a cardboard scratching post.",
         "Your sense of humor must be on vacation.",
         "I'd tell you to go outside, but nature deserves better.",
+        "I've coughed up hairballs with more wit.",
+        "If ignorance was a sport, you'd take gold.",
+        "You're the aftertaste of stale tuna.",
+        "Even Grimm's puns are better than yours.",
+        "You're proof that evolution has a sense of humor.",
     ]
     await ctx.send(random.choice(burns))
 

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -134,6 +134,11 @@ grimm_responses = [
     "If you want hugs, go to Bloom. If you want doom, come to me.",
     "Curse tried to sell my scythe on eBay.",
     "One day I'll retire to a quiet graveyard.",
+    "The living never stop whining, do they?",
+    "Bloom threatened to knit me a sweater. I'm horrified.",
+    "Curse stole my jaw again. Typical.",
+    "I didn't wake up on the wrong side—there is no bed.",
+    "Bloom says smile more. I say stop talking.",
 ]
 
 # Keywords that trigger short replies
@@ -176,6 +181,11 @@ async def protectbloom(ctx):
         "Back off. The flower stays safe with me. 🪦🛡️",
         "I’m watching you. Touch Bloom and you deal with me.",
         "Step away from the cutesy one, or meet your fate.",
+        "Bloom's under my wing. Move along.",
+        "Try anything and you'll face my scythe.",
+        "Bloom's singing may be loud, but my threats are louder.",
+        "Mess with Bloom and you mess with all of us.",
+        "She's annoying, but she's ours. Hands off.",
     ]
     await ctx.send(random.choice(responses))
     send_status("active", "Protected Bloom.")
@@ -191,6 +201,11 @@ async def roast(ctx, member: discord.Member = None):
         f"{member.mention}, you're not even worth the trouble.",
         f"{member.mention}, if I had a nickel for every brain cell you lost, I’d be immortal.",
         f"{member.mention}, some people were born to goon. You were born to be gooned on.",
+        f"{member.mention}, I’ve seen skeletons with more backbone than you.",
+        f"{member.mention}, you make Curse look polite.",
+        f"{member.mention}, keep talking and I'll fall asleep—again.",
+        f"{member.mention}, even Bloom can't cheer you up.",
+        f"{member.mention}, I'd roast you harder, but I'm lazy.",
     ]
     await ctx.send(random.choice(burns))
     send_status("active", f"Roasted {member.display_name}")
@@ -205,6 +220,11 @@ async def goon(ctx):
         "Who called the goon squad? Oh, it was just you.",
         "Goons assemble. And by goons, I mean the rest of you.",
         "This is my squad, you’re just visiting.",
+        "Gooning isn't a hobby, it's a lifestyle.",
+        "Another meeting of the goon squad? Fine.",
+        "You're honorary goons for the next five minutes.",
+        "Goon mode activated. Try to keep up.",
+        "I lead, you follow. Classic goon dynamics.",
     ]
     await ctx.send(random.choice(responses))
     send_status("active", "Issued goon decree.")
@@ -219,6 +239,11 @@ async def ominous(ctx):
         "I hear footsteps... they're yours.",
         "Sometimes I let people think they’re safe.",
         "Death is just a punchline you don’t want to hear.",
+        "The shadows whisper your name.",
+        "I collect souls like others collect stamps.",
+        "Knock knock. It's doom.",
+        "Your fate just took a darker turn.",
+        "Ever danced with the reaper in the pale moonlight?",
     ]
     await ctx.send(random.choice(responses))
     send_status("active", "Dropped an ominous hint.")
@@ -233,6 +258,11 @@ async def bloom(ctx):
         "If you see Bloom, tell her I’m not worried about her. At all. Not even a little. 🖤",
         "She's a handful, but she’s my handful.",
         "Don’t let the cutesy act fool you. She’s the real trouble.",
+        "Bloom thinks glitter solves everything. She's wrong.",
+        "If Bloom starts a song, I'm leaving the room.",
+        "She's the heart of this crew, whether I admit it or not.",
+        "Tell Bloom I said hi, but don't make it weird.",
+        "Bloom once tried to give me a makeover. Never again.",
     ]
     await ctx.send(random.choice(responses))
     send_status("active", "Talked about Bloom.")
@@ -247,6 +277,11 @@ async def curse(ctx):
         "That damn cat is up to something again.",
         "If you see Curse, hide the sushi and your pride.",
         "I let Curse think he's in charge sometimes. It keeps the peace.",
+        "Curse swiped my tibia yesterday. I'm still mad.",
+        "If Curse hisses, just run.",
+        "One day Curse will learn manners, but not today.",
+        "Bloom spoils that cat. I just tolerate him.",
+        "I've seen friendlier ghouls than Curse.",
     ]
     await ctx.send(random.choice(responses))
     send_status("active", "Mocked Curse.")
@@ -287,6 +322,11 @@ async def nickname(ctx, member: discord.Member = None):
         "Rattle-boned scatterbrain",
         "Moldy misfit",
         "Walking pile of leftovers",
+        "Half-baked horror",
+        "Crooked cranium",
+        "Shaky shinbone",
+        "Dust-covered dunce",
+        "Wobbly wishbone",
     ]
     await ctx.send(f"{member.mention}, you're a {random.choice(names)}.")
     send_status("active", f"Called {member.display_name} a nickname")
@@ -343,6 +383,11 @@ async def shield(ctx, member: discord.Member = None):
         f"{member.mention}, no harm comes to you on my watch. (Except embarrassment.)",
         f"Stand behind me, {member.mention}. The goon squad’s got you.",
         f"{member.mention}, if anyone messes with you, send them to me.",
+        f"I've got your back, {member.mention}. Don't make me regret it.",
+        f"Stay close, {member.mention}. I tolerate you.",
+        f"{member.mention}, I'm your shield...begrudgingly.",
+        f"Anyone crosses you, {member.mention}, they answer to my scythe.",
+        f"Consider yourself guarded, {member.mention}. For now.",
     ]
     await ctx.send(random.choice(shields))
     send_status("active", f"Shielded {member.display_name}")

--- a/grimm_utils.py
+++ b/grimm_utils.py
@@ -7,6 +7,11 @@ LAMENTS = [
     "Why does everyone assume I want to talk?",
     "Being undead is overrated.",
     "My scythe gets more respect than I do.",
+    "I miss the quiet of the crypt.",
+    "These bones ache in ways you wouldn't believe.",
+    "Immortality comes with endless paperwork.",
+    "Is it too much to ask for some eternal rest?",
+    "Even my shadows are tired of me.",
 ]
 
 INVENTORY_ITEMS = [
@@ -20,6 +25,11 @@ INVENTORY_ITEMS = [
     "a bundle of wilted roses",
     "a skull-shaped flask",
     "a bone polishing kit",
+    "a jar of grave dirt",
+    "a cracked monocle",
+    "a pocket full of spider webs",
+    "a rusted lock with no key",
+    "a map to nowhere",
 ]
 
 


### PR DESCRIPTION
## Summary
- extend GrimmBot response lists and nicknames
- enrich BloomBot responses and interactions
- flesh out CurseBot replies, gifts, and keywords
- add more laments and inventory items
- document interactive installer prompts in `INSTALL.md`
- mention installer prompts in `README`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887df4876f08321a5b2d3eb49925566