### PR TITLE
Enable Bloom music playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ Commands use the `*` prefix:
 - `*curse` – tease Curse.
 - `*cheer` – offer encouragement.
 - `*sparkle` – throw confetti (and maybe cover you in glitter).
-- `*drama` – start a musical.
+- `*drama` – gush about **EPIC: The Musical** and list every song.
+- `*play <url>` – stream audio from a YouTube link.
+- `*stop` – stop playback and disconnect.
 - `*bloom` – introduce Bloom.
 - `*mood` – display Bloom's mood.
 - `*improv` – begin improv.
@@ -117,6 +119,7 @@ Commands use the `*` prefix:
 - `*compliment` – send a random compliment.
 - `*boy` – share a playful boy-themed line.
 - `*queen` – share a playful "yas queen" line.
+- Mention "epic" and Bloom will rant and play a clip if you're in voice.
 
 ### CurseBot
 - `?curse @user` – manually curse a user (admin only).
@@ -143,8 +146,8 @@ goons for too long and the gifts turn sour, stripping that protection.
 - `trivia` – play a quick trivia round.
 - `kick/ban` – moderation commands restricted to users with the appropriate permissions.
 - `clear` – remove a handful of recent messages.
-- `play <url>` – stream music from YouTube into a voice channel.
-- `stop` – stop music and disconnect from voice.
+- `play <url>` – (use `*play`) stream music from YouTube into a voice channel.
+- `stop` – (use `*stop`) stop music and disconnect from voice.
 - `chat <prompt>` – ask ChatGPT a question and get an in-character reply.
 - `roll [sides]` – roll a dice with an optional number of sides.
 - `8ball <question>` – consult the magic 8-ball.

--- a/docs/cogs_overview.md
+++ b/docs/cogs_overview.md
@@ -7,7 +7,7 @@ what mischief it adds.
 | --- | ------- |
 | `admin_cog.py` | Commands for loading, unloading and reloading other cogs at runtime. Owner only. |
 | `announcement_cog.py` | Sends periodic announcements and exposes a `serverinfo` command describing the configured server layout. |
-| `bloom_cog.py` | Implements the cheerful Bloom personality as a cog. |
+| `bloom_cog.py` | Implements the cheerful Bloom personality with `*play` music commands and an EPIC musical trigger. |
 | `curse_cog.py` | Implements the mischievous Curse personality. |
 | `grimm_cog.py` | Implements the grumpy Grimm personality. |
 | `grimm_extra_cog.py` | Extra utilities for Grimm: gloom meter, laments and bonks. |


### PR DESCRIPTION
## Summary
- add yt_dlp import
- implement `*play` and `*stop` music commands for Bloom
- document the EPIC musical trigger and playback features
- describe Bloom's new capabilities in cog overview

## Testing
- `python -m py_compile bloom_bot.py cogs/bloom_cog.py`

------
https://chatgpt.com/codex/tasks/task_e_6887e4949448832182a5401c51101c34