### PR TITLE
Enhance music cog with playlist queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ Commands use the `*` prefix:
 - `*curse` – tease Curse.
 - `*cheer` – offer encouragement.
 - `*sparkle` – throw confetti (and maybe cover you in glitter).
-- `*drama` – gush about **EPIC: The Musical** and list every song.
-- `*play <url>` – stream audio from a YouTube link.
-- `*stop` – stop playback and disconnect.
+ - `*drama` – gush about **EPIC: The Musical** and list every song.
+ - `*play <url>` – queue a YouTube link or playlist.
+ - `*next` – skip to the next song.
+ - `*queue` – view the upcoming songs.
+ - `*stop` – stop playback, clear the queue and disconnect.
 - `*bloom` – introduce Bloom.
 - `*mood` – display Bloom's mood.
 - `*improv` – begin improv.

--- a/cogs/music_cog.py
+++ b/cogs/music_cog.py
@@ -3,15 +3,17 @@ from discord.ext import commands
 import yt_dlp
 import requests
 from bs4 import BeautifulSoup
+from typing import Dict, List
 
-COG_VERSION = "1.2"
+COG_VERSION = "1.3"
 
 
 class MusicCog(commands.Cog):
-    """Basic music playback commands. Version 1.2."""
+    """Basic music playback commands with queue support. Version 1.3."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self.queues: Dict[int, List[dict]] = {}
 
     async def ensure_voice(self, ctx):
         if ctx.author.voice is None or ctx.author.voice.channel is None:
@@ -24,19 +26,45 @@ class MusicCog(commands.Cog):
             await voice.move_to(ctx.author.voice.channel)
         return voice
 
+    async def play_next(self, ctx):
+        guild_id = ctx.guild.id
+        voice = ctx.voice_client
+        queue = self.queues.get(guild_id)
+        if not queue:
+            if voice and voice.is_connected():
+                await ctx.send("Queue ended.")
+            return
+        next_track = queue.pop(0)
+        source = await discord.FFmpegOpusAudio.from_probe(next_track["url"])
+        voice.play(
+            source,
+            after=lambda _: self.bot.loop.create_task(self.play_next(ctx)),
+        )
+        await ctx.send(f"Now playing: {next_track.get('title', 'unknown')}")
+
     @commands.command()
     async def play(self, ctx, url: str):
-        """Stream audio from a YouTube URL."""
+        """Queue a YouTube URL or playlist."""
         voice = await self.ensure_voice(ctx)
         if not voice:
             return
+
+        guild_id = ctx.guild.id
+        queue = self.queues.setdefault(guild_id, [])
         ydl_opts = {"format": "bestaudio", "quiet": True}
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info = ydl.extract_info(url, download=False)
-            audio_url = info["url"]
-        source = await discord.FFmpegOpusAudio.from_probe(audio_url)
-        voice.play(source)
-        await ctx.send(f"Now playing: {info.get('title', 'unknown')}")
+
+        if "entries" in info:
+            for entry in info["entries"]:
+                queue.append({"url": entry["url"], "title": entry.get("title")})
+            await ctx.send(f"Added {len(info['entries'])} songs to the queue.")
+        else:
+            queue.append({"url": info["url"], "title": info.get("title")})
+            await ctx.send(f"Queued: {info.get('title', 'unknown')}")
+
+        if not voice.is_playing():
+            await self.play_next(ctx)
 
     @commands.command()
     async def spotify(self, ctx, url: str):
@@ -54,12 +82,32 @@ class MusicCog(commands.Cog):
             return
         await ctx.send(f"Pretending to play **{track}** from Spotify. Feel the vibes!")
 
+    @commands.command(name="next")
+    async def next_song(self, ctx):
+        """Skip to the next song in the queue."""
+        if ctx.voice_client and ctx.voice_client.is_playing():
+            ctx.voice_client.stop()
+        await self.play_next(ctx)
+
+    @commands.command(name="queue")
+    async def queue_list(self, ctx):
+        """Display the upcoming songs."""
+        queue = self.queues.get(ctx.guild.id, [])
+        if not queue:
+            await ctx.send("Queue is empty.")
+            return
+        msg = "Upcoming songs:\n" + "\n".join(
+            f"{idx + 1}. {item.get('title', 'unknown')}" for idx, item in enumerate(queue)
+        )
+        await ctx.send(msg)
+
     @commands.command()
     async def stop(self, ctx):
         """Stop playback and disconnect."""
         if ctx.voice_client:
             await ctx.voice_client.disconnect()
-            await ctx.send("Disconnected.")
+        self.queues.pop(ctx.guild.id, None)
+        await ctx.send("Disconnected.")
 
 
 async def setup(bot: commands.Bot):

--- a/docs/cogs_overview.md
+++ b/docs/cogs_overview.md
@@ -13,7 +13,7 @@ what mischief it adds.
 | `grimm_extra_cog.py` | Extra utilities for Grimm: gloom meter, laments and bonks. |
 | `fun_cog.py` | Provides quick games like dice rolls, coin flips and an 8‑ball. |
 | `trivia_cog.py` | Simple trivia mini‑game. |
-| `music_cog.py` | Stream audio from YouTube links into voice channels. |
+| `music_cog.py` | Queue YouTube links or playlists with basic controls. |
 | `moderation_cog.py` | Basic moderation commands (`kick`, `ban`, `clear`). |
 | `gpt_cog.py` | ChatGPT based chat command and mention replies. Requires `OPENAI_API_KEY`. |
 | `jojo_cog.py` | Sends loving messages to a user named "JoJo is bizarre". |


### PR DESCRIPTION
## Summary
- support playlists and queues in `music_cog`
- document new queue commands
- describe updated music functionality in docs

## Testing
- `python -m py_compile cogs/music_cog.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e5c964948321819784f585333892