### PR TITLE
Add universal help commands for all bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ python install.py     # reconfigure on the fly
 GrimmBot can broadcast status to a Socket.IO dashboard if you define
 `SOCKET_SERVER_URL` inside `config/setup.env`.
 
+## Help commands
+
+Every goon responds to a personalized `help` command using its prefix:
+
+- `!help` for GrimmBot
+- `*help` for BloomBot
+- `?help` for CurseBot
+
+Use `helpall` with any prefix to have all three introduce themselves at once.
+
 ## Command reference
 
 Here's a taste of what each bot can do.

--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -31,7 +31,7 @@ BLOOM_API_KEY_3 = os.getenv("BLOOM_API_KEY_3")
 
 intents = discord.Intents.default()
 intents.message_content = True
-bot = commands.Bot(command_prefix="*", intents=intents)
+bot = commands.Bot(command_prefix="*", intents=intents, help_command=None)
 
 # === Bloom Personality ===
 bloom_personality = {
@@ -86,6 +86,23 @@ bloom_responses = [
     "Glitter makes everything better, trust me!",
     "Let's turn this chat into a mini musical!",
 ]
+
+# Short help message used by the help commands
+BLOOM_HELP = (
+    "**BloomBot** - prefix `*`\n"
+    "Try `*hug`, `*sing`, `*sparkle`, `*play <url>` and more.\n"
+    "Use `*helpall` to see help for every goon."
+)
+
+GRIMM_HELP = (
+    "**GrimmBot** - prefix `!`\n"
+    "Try `!protectbloom`, `!roast`, `!gloom`, `!bonk` and more."
+)
+
+CURSE_HELP = (
+    "**CurseBot** - prefix `?`\n"
+    "Try `?insult`, `?scratch @user`, `?pounce` or `?curse_me`."
+)
 
 # === Bloom Boy Lines ===
 boy_lines = [
@@ -300,6 +317,20 @@ interactions = [
 @bot.event
 async def on_ready():
     print(f"{bloom_personality['name']} is online and ready to hug the whole server!")
+
+
+@bot.command(name="help")
+async def help_command(ctx):
+    """Show BloomBot help."""
+    await ctx.send(BLOOM_HELP)
+
+
+@bot.command(name="helpall")
+async def help_all(ctx):
+    """Show help for all bots."""
+    await ctx.send(GRIMM_HELP)
+    await ctx.send(BLOOM_HELP)
+    await ctx.send(CURSE_HELP)
 
 
 # === Message Handler ===

--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -2,5 +2,5 @@
 
 from pathlib import Path
 
-PACKAGE_VERSION = "1.2"
+PACKAGE_VERSION = "1.3"
 __all__ = [p.stem for p in Path(__file__).parent.glob("*_cog.py")]

--- a/cogs/help_cog.py
+++ b/cogs/help_cog.py
@@ -1,0 +1,52 @@
+from discord.ext import commands
+
+COG_VERSION = "1.0"
+
+# Short help messages for each bot so they can be reused in other commands
+GRIMM_HELP = (
+    "**GrimmBot** (`!` prefix) - the cranky skeleton.\n"
+    "Try commands like `!protectbloom`, `!gloom`, `!roast` and `!bonk`."
+)
+
+BLOOM_HELP = (
+    "**BloomBot** (`*` prefix) - bubbly chaos.\n"
+    "Try `*hug`, `*sing`, `*sparkle`, `*play <url>` and more."
+)
+
+CURSE_HELP = (
+    "**CurseBot** (`?` prefix) - the mischievous cat.\n"
+    "Try `?insult`, `?scratch @user`, `?pounce` or `?curse_me`."
+)
+
+
+class HelpCog(commands.Cog):
+    """Provide help commands for the goons. Version 1.0."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command(name="grimmhelp")
+    async def grimm_help(self, ctx: commands.Context):
+        """Show help for GrimmBot."""
+        await ctx.send(GRIMM_HELP)
+
+    @commands.command(name="bloomhelp")
+    async def bloom_help(self, ctx: commands.Context):
+        """Show help for BloomBot."""
+        await ctx.send(BLOOM_HELP)
+
+    @commands.command(name="cursehelp")
+    async def curse_help(self, ctx: commands.Context):
+        """Show help for CurseBot."""
+        await ctx.send(CURSE_HELP)
+
+    @commands.command(name="helpall")
+    async def help_all(self, ctx: commands.Context):
+        """Show help for all bots at once."""
+        for msg in (GRIMM_HELP, BLOOM_HELP, CURSE_HELP):
+            await ctx.send(msg)
+
+
+async def setup(bot: commands.Bot):
+    """Load the cog."""
+    await bot.add_cog(HelpCog(bot))

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -31,7 +31,7 @@ intents = discord.Intents.default()
 intents.message_content = True
 intents.members = True
 intents.presences = True
-bot = commands.Bot(command_prefix="?", intents=intents)
+bot = commands.Bot(command_prefix="?", intents=intents, help_command=None)
 
 # === CurseBot Personality ===
 curse_personality = {
@@ -181,6 +181,23 @@ curse_responses = [
     "Try me again and I'll curse your coffee.",
     "I run this squad, the others just pretend.",
 ]
+
+# Short help message used by the help commands
+CURSE_HELP = (
+    "**CurseBot** - prefix `?`\n"
+    "Try `?insult`, `?scratch @user`, `?pounce` or `?curse_me`.\n"
+    "Use `?helpall` to see help for every goon."
+)
+
+GRIMM_HELP = (
+    "**GrimmBot** - prefix `!`\n"
+    "Try `!protectbloom`, `!roast`, `!gloom`, `!bonk` and more."
+)
+
+BLOOM_HELP = (
+    "**BloomBot** - prefix `*`\n"
+    "Try `*hug`, `*sing`, `*sparkle`, `*play <url>` and more."
+)
 
 # === Keywords ===
 curse_keywords = {
@@ -375,6 +392,20 @@ async def on_ready():
     print(f"{curse_personality['name']} is here to ruin someone's day.")
     pick_daily_cursed.start()
     daily_gift.start()
+
+
+@bot.command(name="help")
+async def help_command(ctx):
+    """Show CurseBot help."""
+    await ctx.send(CURSE_HELP)
+
+
+@bot.command(name="helpall")
+async def help_all(ctx):
+    """Show help for all bots."""
+    await ctx.send(GRIMM_HELP)
+    await ctx.send(BLOOM_HELP)
+    await ctx.send(CURSE_HELP)
 
 
 # === Passive Comments to Cursed User ===

--- a/docs/cogs_overview.md
+++ b/docs/cogs_overview.md
@@ -18,6 +18,7 @@ what mischief it adds.
 | `gpt_cog.py` | ChatGPT based chat command and mention replies. Requires `OPENAI_API_KEY`. |
 | `jojo_cog.py` | Sends loving messages to a user named "JoJo is bizarre". |
 | `cyberpunk_campaign_cog.py` | Lightweight cyberpunk themed DnD campaign using ChatGPT. |
+| `help_cog.py` | Provides `help` commands for each bot and a `helpall` summary. |
 
 All cogs declare a `COG_VERSION` constant for easy tracking of updates. Load them one by one with `goon_bot.py` or the Admin commands.
 Happy gooning, - Curse

--- a/goon_bot.py
+++ b/goon_bot.py
@@ -24,7 +24,7 @@ async def get_prefix(bot, message):
 
 intents = discord.Intents.default()
 intents.message_content = True
-bot = commands.Bot(command_prefix=get_prefix, intents=intents)
+bot = commands.Bot(command_prefix=get_prefix, intents=intents, help_command=None)
 
 
 @bot.event

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -141,6 +141,23 @@ grimm_responses = [
     "Bloom says smile more. I say stop talking.",
 ]
 
+# Short help message used by the help commands
+GRIMM_HELP = (
+    "**GrimmBot** - prefix `!`\n"
+    "Try `!protectbloom`, `!roast`, `!gloom`, `!bonk` and more.\n"
+    "Use `!helpall` to see help for every goon."
+)
+
+BLOOM_HELP = (
+    "**BloomBot** - prefix `*`\n"
+    "Try `*hug`, `*sing`, `*sparkle`, `*play <url>` and more."
+)
+
+CURSE_HELP = (
+    "**CurseBot** - prefix `?`\n"
+    "Try `?insult`, `?scratch @user`, `?pounce` or `?curse_me`."
+)
+
 # Keywords that trigger short replies
 keywords = {
     "bloom": [
@@ -160,7 +177,7 @@ keywords = {
 # === DISCORD BOT SETUP ===
 intents = discord.Intents.default()
 intents.message_content = True
-bot = commands.Bot(command_prefix="!", intents=intents)
+bot = commands.Bot(command_prefix="!", intents=intents, help_command=None)
 
 # === ON READY ===
 
@@ -169,6 +186,20 @@ bot = commands.Bot(command_prefix="!", intents=intents)
 async def on_ready():
     print("Grimm has arrived. Watch your step, goons.")
     send_status("online", "On patrol. Nobody dies on my watch (except for Mondays).")
+
+
+@bot.command(name="help")
+async def help_command(ctx):
+    """Show GrimmBot help."""
+    await ctx.send(GRIMM_HELP)
+
+
+@bot.command(name="helpall")
+async def help_all(ctx):
+    """Show help for all bots."""
+    await ctx.send(GRIMM_HELP)
+    await ctx.send(BLOOM_HELP)
+    await ctx.send(CURSE_HELP)
 
 
 # === MODERATION: PROTECT BLOOM (JOKINGLY) ===


### PR DESCRIPTION
## Summary
- add new `help_cog` with `help`, bot intros and `helpall`
- update bot scripts to register custom help commands
- document help usage in README
- document new cog in cogs overview
- bump package version

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6887ed9cacac83219f8a6b424de8e3e2