### PR TITLE
Unify build version to 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ We're lightweight, each in our own Python file. Fire up `goon_bot.py` if you
 want the whole chaotic crew. It loads every cog and lets an Admin hot‑swap
 modules whenever you feel like causing trouble.
 
+**Current build: v1.3**
+
 ## Repository layout
 
 Here's what you'll find lurking in the repo:

--- a/cogs/admin_cog.py
+++ b/cogs/admin_cog.py
@@ -1,10 +1,10 @@
 from discord.ext import commands
 
-COG_VERSION = "1.2"
+COG_VERSION = "1.3"
 
 
 class AdminCog(commands.Cog):
-    """Administration utilities for managing cogs. Version 1.2."""
+    """Administration utilities for managing cogs. Version 1.3."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/announcement_cog.py
+++ b/cogs/announcement_cog.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands, tasks
 
-COG_VERSION = "1.2"
+COG_VERSION = "1.3"
 
 # Server reference information for quick access
 SERVER_ROLES = [
@@ -20,7 +20,7 @@ SERVER_CATEGORIES = {
 
 
 class AnnouncementCog(commands.Cog):
-    """Send periodic announcements and list server layout. Version 1.2."""
+    """Send periodic announcements and list server layout. Version 1.3."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/cyberpunk_campaign_cog.py
+++ b/cogs/cyberpunk_campaign_cog.py
@@ -3,7 +3,7 @@ import random
 import openai
 from discord.ext import commands
 
-COG_VERSION = "1.2"
+COG_VERSION = "1.3"
 
 # Environment values are read from the parent process
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -11,7 +11,7 @@ openai.api_key = OPENAI_API_KEY
 
 
 class CyberpunkCampaignCog(commands.Cog):
-    """Cyberpunk themed mini DnD campaign with simple character sheets. Version 1.2."""
+    """Cyberpunk themed mini DnD campaign with simple character sheets. Version 1.3."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/fun_cog.py
+++ b/cogs/fun_cog.py
@@ -1,11 +1,11 @@
 from discord.ext import commands
 import random
 
-COG_VERSION = "1.2"
+COG_VERSION = "1.3"
 
 
 class FunCog(commands.Cog):
-    """Random fun commands like dice rolls and an 8-ball. Version 1.2."""
+    """Random fun commands like dice rolls and an 8-ball. Version 1.3."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/gpt_cog.py
+++ b/cogs/gpt_cog.py
@@ -2,7 +2,7 @@ import os
 import openai
 from discord.ext import commands
 
-COG_VERSION = "1.2"
+COG_VERSION = "1.3"
 
 # Environment values are read from the parent process
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -16,7 +16,7 @@ SYSTEM_MESSAGES = {
 
 
 class GPTCog(commands.Cog):
-    """Cog that adds a ChatGPT-based chat command and mention replies. Version 1.2."""
+    """Cog that adds a ChatGPT-based chat command and mention replies. Version 1.3."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/grimm_extra_cog.py
+++ b/cogs/grimm_extra_cog.py
@@ -4,11 +4,11 @@ from discord.ext import commands
 
 from . import grimm_utils
 
-COG_VERSION = "1.2"
+COG_VERSION = "1.3"
 
 
 class GrimmExtraCog(commands.Cog):
-    """Additional utilities and fun commands for Grimm. Version 1.2."""
+    """Additional utilities and fun commands for Grimm. Version 1.3."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/help_cog.py
+++ b/cogs/help_cog.py
@@ -1,6 +1,6 @@
 from discord.ext import commands
 
-COG_VERSION = "1.0"
+COG_VERSION = "1.3"
 
 # Short help messages for each bot so they can be reused in other commands
 GRIMM_HELP = (
@@ -20,7 +20,7 @@ CURSE_HELP = (
 
 
 class HelpCog(commands.Cog):
-    """Provide help commands for the goons. Version 1.0."""
+    """Provide help commands for the goons. Version 1.3."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/jojo_cog.py
+++ b/cogs/jojo_cog.py
@@ -3,14 +3,14 @@ import discord
 import datetime
 import random
 
-COG_VERSION = "1.2"
+COG_VERSION = "1.3"
 
 JOJO_DISPLAY_NAME = "JoJo is bizarre"
 EMMA_NAME = "Emma"
 
 
 class JojoCog(commands.Cog):
-    """Send spontaneous loving messages to Emma. Version 1.2."""
+    """Send spontaneous loving messages to Emma. Version 1.3."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/moderation_cog.py
+++ b/cogs/moderation_cog.py
@@ -1,11 +1,11 @@
 import discord
 from discord.ext import commands
 
-COG_VERSION = "1.2"
+COG_VERSION = "1.3"
 
 
 class ModerationCog(commands.Cog):
-    """Basic moderation commands. Version 1.2."""
+    """Basic moderation commands. Version 1.3."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/configure.py
+++ b/configure.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 TEMPLATE_PATH = Path("config/env_template.env")
 SETUP_PATH = Path("config/setup.env")
-VERSION = "1.2"
+VERSION = "1.3"
 
 
 def read_existing(path: Path) -> dict:

--- a/docs/cogs_overview.md
+++ b/docs/cogs_overview.md
@@ -1,7 +1,7 @@
 # Cogs Overview
 
 Curse here again. Here's a quick summary of each cog bundled with Grimmbot and
-what mischief it adds.
+what mischief it adds. All cogs are currently **v1.3**.
 
 | Cog | Purpose |
 | --- | ------- |

--- a/install.py
+++ b/install.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 import shutil
 
-VERSION = "1.2"
+VERSION = "1.3"
 
 TEMPLATE_PATH = Path("config/env_template.env")
 SETUP_PATH = Path("config/setup.env")


### PR DESCRIPTION
## Summary
- bump installer and config helper version numbers
- update all cogs to declare COG_VERSION 1.3
- note the current build version in README and docs

## Testing
- `python -m compileall -q .`
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_e_6887f1cb867483219ffca3b5cb85228f