### PR TITLE
Add interactive drama command

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Commands use the `*` prefix:
 - `*curse` – tease Curse.
 - `*cheer` – offer encouragement.
 - `*sparkle` – throw confetti (and maybe cover you in glitter).
- - `*drama` – sing a random snippet from **EPIC: The Musical**.
+ - `*drama [song|list]` – pick a song from **EPIC: The Musical** and decide to sing a short snippet or the whole thing.
+   Add your own lyric files under `localtracks/epic_lyrics/` if you want full songs.
  - `*play <url>` – queue a YouTube link or playlist.
  - `*next` – skip to the next song.
  - `*queue` – view the upcoming songs.

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -3,8 +3,7 @@ from discord.ext import commands, tasks
 import random
 import os
 import yt_dlp
-import asyncio
-from bloom_bot import epic_songs, epic_lyrics
+from bloom_bot import perform_drama
 
 COG_VERSION = "1.3"
 
@@ -369,18 +368,9 @@ class BloomCog(commands.Cog):
             )
 
     @commands.command()
-    async def drama(self, ctx):
-        all_songs = [song for songs in epic_songs.values() for song in songs]
-        song = random.choice(all_songs)
-        await ctx.send(f"🎭 **EPIC: The Musical** – let's sing **{song}**!")
-        lyrics = epic_lyrics.get(song)
-        if not lyrics:
-            await ctx.send("(Lyrics missing – add them in epic_lyrics to sing along!)")
-            return
-        line_count = random.randint(1, len(lyrics))
-        for line in lyrics[:line_count]:
-            await ctx.send(line)
-            await asyncio.sleep(1)
+    async def drama(self, ctx, *, song: str | None = None):
+        """Perform an EPIC song with interactive prompts."""
+        await perform_drama(self.bot, ctx, song)
 
     @commands.command()
     async def bloom(self, ctx):


### PR DESCRIPTION
## Summary
- add new `perform_drama` helper that loads lyrics from local files and interacts with the user
- expand BloomBot's `drama` command to allow song selection and full-song playback
- update Bloom cog to use the new helper
- document the updated command in the README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f557521883218d579f7e62c7198e