### PR TITLE
Add goon_cog for group interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Here's what you'll find lurking in the repo:
 - `bloom_bot.py` – Bloom brings bubbly chaos (prefix `*`).
 - `curse_bot.py` – that's me, the mischievous calico (prefix `?`).
 - `goon_bot.py` – pulls us all together as cogs.
+- `cogs/goon_cog.py` – the goon squad speaking in unison.
 - `config/setup.env` – one file to hold all the secret tokens.
 - `requirements/base.txt` – packages the installer grabs.
 - `bootstrap.sh` – one-liner to clone and run the setup.

--- a/cogs/goon_cog.py
+++ b/cogs/goon_cog.py
@@ -1,0 +1,43 @@
+import random
+from discord.ext import commands
+
+COG_VERSION = "1.3"
+
+
+class GoonCog(commands.Cog):
+    """Group lines from all bots together. Version 1.3."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.greetings = [
+            "Grimm grumbles, Bloom cheers and Curse hisses: the goons arrive!",
+            "The squad assembles – Bloom waves, Grimm nods and Curse flicks his tail.",
+            "You summoned all of us! Expect chaos and hugs... and hissing.",
+        ]
+        self.reactions = [
+            "All three chatter at once, making an utter mess of the chat.",
+            "Grimm sighs, Bloom giggles, Curse paws at you. Goon squad energy!",
+            "The room suddenly feels crowded with goons.",
+        ]
+
+    @commands.command()
+    async def greetall(self, ctx):
+        """Greet from the entire goon squad."""
+        await ctx.send(random.choice(self.greetings))
+
+    @commands.command()
+    async def goonsay(self, ctx, *, text: str):
+        """Echo a message with squad flair."""
+        await ctx.send(f"Grimm, Bloom and Curse chant together: {text}")
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if message.author == self.bot.user or message.author.bot:
+            return
+        lowered = message.content.lower()
+        if any(k in lowered for k in ("goons", "squad")) and random.random() < 0.2:
+            await message.channel.send(random.choice(self.reactions))
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(GoonCog(bot))

--- a/docs/cogs_overview.md
+++ b/docs/cogs_overview.md
@@ -19,6 +19,7 @@ what mischief it adds. All cogs are currently **v1.3**.
 | `jojo_cog.py` | Sends loving messages to a user named "JoJo is bizarre". |
 | `cyberpunk_campaign_cog.py` | Lightweight cyberpunk themed DnD campaign using ChatGPT. |
 | `help_cog.py` | Provides `help` commands for each bot and a `helpall` summary. |
+| `goon_cog.py` | The whole squad chiming in together. |
 
 All cogs declare a `COG_VERSION` constant for easy tracking of updates. Load them one by one with `goon_bot.py` or the Admin commands.
 Happy gooning, - Curse


### PR DESCRIPTION
## Summary
- create `goon_cog.py` for unified goon banter
- document the new cog in README and cogs overview

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6887f6498eb88321a20fbc4300cc85c6