### PR TITLE
Add music setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Prefer manual control? Follow these steps in your terminal:
 
 For more nitty‑gritty steps check out [`INSTALL.md`](INSTALL.md).
 
+The music commands require **FFmpeg** to be installed and available in your
+`PATH`. If you want BloomBot to sing along to EPIC: The Musical, place lyric
+files under `localtracks/epic_lyrics/`. See [`docs/music_setup.md`](docs/music_setup.md)
+for details.
+
 ## Running the bots
 
 Once `config/setup.env` is filled in you can unleash any bot directly or through

--- a/docs/cogs_overview.md
+++ b/docs/cogs_overview.md
@@ -22,4 +22,5 @@ what mischief it adds. All cogs are currently **v1.3**.
 | `goon_cog.py` | The whole squad chiming in together. |
 
 All cogs declare a `COG_VERSION` constant for easy tracking of updates. Load them one by one with `goon_bot.py` or the Admin commands.
+For music playback details see [`music_setup.md`](music_setup.md).
 Happy gooning, - Curse

--- a/docs/music_setup.md
+++ b/docs/music_setup.md
@@ -1,0 +1,15 @@
+# Music Setup
+
+BloomBot and the `music_cog.py` rely on FFmpeg for audio playback. Install it using your package manager:
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install ffmpeg
+
+# macOS (Homebrew)
+brew install ffmpeg
+```
+
+For advanced playback via Lavalink, make sure a Lavalink server is running and update the connection details inside `media_player.py` if needed.
+
+Place optional audio files in the [`localtracks`](../localtracks) folder. BloomBot looks for lyrics in `localtracks/epic_lyrics` when you use `*drama`.

--- a/localtracks/README.md
+++ b/localtracks/README.md
@@ -1,0 +1,18 @@
+# Local Tracks
+
+This folder holds optional audio and lyric files used by BloomBot and the music player.
+
+- Put MP3/FLAC/OGG files directly in this folder or any subfolder to play them with the `*play` command.
+- To sing along with **EPIC: The Musical**, create a subfolder called `epic_lyrics` and place one text file per song. Each file should be named exactly like the song title with a `.txt` extension.
+
+Example:
+
+```
+localtracks/
+└── epic_lyrics/
+    └── The Horse and the Infant.txt
+```
+
+Each lyric file should contain one line per lyric. BloomBot will load the text and recite a few random lines when you trigger the `*drama` command.
+
+These files are optional; if none are found BloomBot will still work but simply note that the lyrics are missing.

--- a/localtracks/epic_lyrics/README.md
+++ b/localtracks/epic_lyrics/README.md
@@ -1,0 +1,2 @@
+Place plain text lyric files here to have BloomBot recite songs from EPIC: The Musical.
+Each file should be named after the song with a `.txt` extension.


### PR DESCRIPTION
## Summary
- document optional audio & lyric files
- mention FFmpeg requirement and link to music_setup.md
- explain in docs when to refer to music setup for more details

## Testing
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_e_6887f77dd86883218f0bb479f98002af