### PR TITLE
Add cyberpunk adventure doc

### DIFF
--- a/docs/cogs_overview.md
+++ b/docs/cogs_overview.md
@@ -16,7 +16,7 @@ what mischief it adds. All cogs are currently **v1.3**.
 | `music_cog.py` | Queue YouTube links or playlists with basic controls. |
 | `moderation_cog.py` | Basic moderation commands (`kick`, `ban`, `clear`). |
 | `gpt_cog.py` | ChatGPT based chat command and mention replies. Requires `OPENAI_API_KEY`. |
-| `cyberpunk_campaign_cog.py` | Lightweight cyberpunk themed DnD campaign using ChatGPT. |
+| `cyberpunk_campaign_cog.py` | Lightweight cyberpunk themed DnD campaign using ChatGPT. See [cyberpunk_adventure.md](cyberpunk_adventure.md) for expanded scenarios. |
 | `help_cog.py` | Provides `help` commands for each bot and a `helpall` summary. |
 | `goon_cog.py` | The whole squad chiming in together. |
 

--- a/docs/cyberpunk_adventure.md
+++ b/docs/cyberpunk_adventure.md
@@ -1,0 +1,94 @@
+# Expanded Cyberpunk Campaign
+
+Below are fifty modular scenario prompts for **Neon Goon City**. Shuffle or mix them to build unique sessions. Use the prompts as starting points for ChatGPT to elaborate on in character.
+
+## Scenario Seeds
+1. You wake to blaring sirens as a corporate raid sweeps the district.
+2. A street vendor offers mysterious cyberware of unknown origin.
+3. Grimm receives a coded message from an old ally begging for help.
+4. Bloom discovers a hidden theater filled with holographic actors.
+5. Curse spots a rival gang marking territory near your hideout.
+6. A neon-lit train screeches to a halt, its doors stuck open.
+7. A lost child clings to a malfunctioning robot, asking for repair.
+8. The city grid flickers, plunging blocks into sudden darkness.
+9. A famous DJ offers you a job guarding their secret concert.
+10. An old netrunner warns of a virus spreading through implants.
+11. You stumble upon an underground fight club with high-tech rules.
+12. A rogue AI broadcasts cryptic poetry over every screen.
+13. The police have cordoned off a market after a mysterious blast.
+14. Bloom senses restless spirits haunting a derelict skyscraper.
+15. Grimm is challenged to a duel by a cyber-enhanced rival.
+16. Curse finds a map leading to a rumored sushi paradise.
+17. A hacker collective seeks allies for a massive data heist.
+18. Corporate drones patrol the skies looking for fugitives.
+19. A powerful gang leader offers protection—for a price.
+20. You intercept chatter about a prototype weapon up for auction.
+21. Bloom is invited to star in an experimental musical.
+22. Grimm uncovers rumors of a skeleton cult forming in secret.
+23. Curse steals a glimmering gem that hums with energy.
+24. A local clinic is overrun with victims of a new street drug.
+25. An ancient subway tunnel reveals doors to a lost sector.
+26. You meet a prophetic techie who dreams of impending doom.
+27. Rogue mechs roam the scrapyard after dark.
+28. A radio station requests on-air heroes to solve riddles live.
+29. The government announces sudden martial law.
+30. A wealthy patron hires you to retrieve a priceless artifact.
+31. Bloom hears whispers of a concert that summons the dead.
+32. Grimm's old nemesis resurfaces with cybernetic upgrades.
+33. A hacker sells a map of secret corporate elevators.
+34. Curse discovers a talking drone desperate to escape.
+35. The streets flood as sewers overflow with neon sludge.
+36. You catch sight of a hidden oasis in the sprawling slums.
+37. The mayor declares a curfew after repeated power outages.
+38. A covert lab experiments on animals for combat implants.
+39. Grimm receives a box containing a single bone and a riddle.
+40. Bloom rescues a stray spirit bound inside a crystal shard.
+41. A rogue satellite crashes, scattering tech salvage everywhere.
+42. Word spreads of a legendary hacker selling their services.
+43. Curse wagers with an info broker over a game of chance.
+44. A mercenary team mistakes you for their target.
+45. Strange graffiti points toward a forgotten cyber-temple.
+46. The city hospital urgently needs supplies from a dangerous zone.
+47. A rival crew sabotages your safehouse, leaving clues behind.
+48. You awaken to find the city sealed by towering energy walls.
+49. Bloom senses a tear between dimensions leaking ghostly lights.
+50. Grimm hears rumors of a weapon capable of erasing memories.
+
+## Decision Tree
+Start with any scenario seed and follow the choices. Each choice leads to a numbered node. Endings are marked **E1**–**E10**.
+
+```
+1. Investigate the threat         -> 2 or 3
+2. Negotiate with local gangs     -> 4 or 5
+3. Seek aid from corporate rivals -> 6 or 7
+4. Infiltrate a guarded facility  -> 8 or 9
+5. Rally street allies            -> 10 or 11
+6. Attempt a high-stakes heist    -> 12 or 13
+7. Explore the haunted outskirts  -> 14 or 15
+8. Uncover forbidden tech         -> 16 or 17
+9. Protect innocents at all cost  -> 18 or 19
+10. Betray an uneasy ally         -> E1 or E2
+11. Declare open war              -> E3 or E4
+12. Acquire immense power         -> E5
+13. Trigger a catastrophic event  -> E6
+14. Discover an alternate reality -> E7 or E8
+15. Escape the city entirely      -> E9 or E10
+16. Expose corporate corruption   -> E1 or E5
+17. Unleash a rogue AI            -> E6 or E7
+18. Become heroes of the people   -> E3 or E9
+19. Sacrifice for the greater good-> E4 or E10
+```
+
+## Endings
+- **E1**: The crew strikes a deal, balancing power between gangs and corporations.
+- **E2**: Negotiations fail, and the city plunges into turf wars.
+- **E3**: Citizens hail the crew as champions of freedom.
+- **E4**: The uprising collapses, leaving the city under harsher rule.
+- **E5**: Forbidden tech grants near-limitless influence but at a moral cost.
+- **E6**: A reckless choice unleashes devastation, scattering the crew.
+- **E7**: The team vanishes into a mysterious parallel world.
+- **E8**: Reality fractures, merging dimensions in chaotic harmony.
+- **E9**: The crew escapes to start anew, legends whispered behind them.
+- **E10**: Sacrifice saves the city, but the crew is lost to history.
+
+Use these endings or create your own with ChatGPT. Mix scenarios freely—the more you shuffle, the wilder the adventure becomes.


### PR DESCRIPTION
## Summary
- add a `cyberpunk_adventure.md` doc with 50 scenario seeds, a decision tree and ten endings
- reference the new doc from `cogs_overview.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688807f809988321a5ea3124e86f5976