### PR TITLE
Format with black and adjust flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 150
+ignore = E203,W503

--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -285,7 +285,9 @@ def load_epic_lyrics(song: str) -> list[str]:
         return [line.strip() for line in f if line.strip()]
 
 
-async def perform_drama(bot: commands.Bot, ctx: commands.Context, song: str | None = None):
+async def perform_drama(
+    bot: commands.Bot, ctx: commands.Context, song: str | None = None
+):
     """Interactive EPIC sing-along helper."""
     all_songs = [s for songs in epic_songs.values() for s in songs]
 
@@ -334,11 +336,12 @@ async def perform_drama(bot: commands.Bot, ctx: commands.Context, song: str | No
     else:
         count = max(1, min(len(lyrics), random.randint(4, 8)))
         start = random.randint(0, max(0, len(lyrics) - count))
-        lines_to_send = lyrics[start:start + count]
+        lines_to_send = lyrics[start : start + count]
 
     for line in lines_to_send:
         await ctx.send(line)
         await asyncio.sleep(1)
+
 
 # Lines from Bloom's favorite song "Pretty Little Baby" by Connie Francis
 pretty_little_baby_lines = [
@@ -492,9 +495,7 @@ async def sparkle(ctx):
                 "Bloom thinks you're fabulous!",
             ]
         )
-        await ctx.send(
-            f"{ctx.author.mention} gets covered in glitter! {compliment}"
-        )
+        await ctx.send(f"{ctx.author.mention} gets covered in glitter! {compliment}")
 
 
 @bot.command()

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -251,7 +251,9 @@ class BloomCog(commands.Cog):
         guild = member.guild
         role = discord.utils.get(guild.roles, name="Bloom's Blessing")
         if role is None:
-            role = await guild.create_role(name="Bloom's Blessing", colour=discord.Colour.magenta())
+            role = await guild.create_role(
+                name="Bloom's Blessing", colour=discord.Colour.magenta()
+            )
         try:
             await member.add_roles(role)
         except discord.Forbidden:
@@ -292,7 +294,9 @@ class BloomCog(commands.Cog):
             info = ydl.extract_info(EPIC_VIDEO_URL, download=False)
             audio_url = info["url"]
         source = await discord.FFmpegOpusAudio.from_probe(audio_url)
-        voice.play(source, after=lambda e: self.bot.loop.create_task(voice.disconnect()))
+        voice.play(
+            source, after=lambda e: self.bot.loop.create_task(voice.disconnect())
+        )
 
     @commands.Cog.listener()
     async def on_ready(self):

--- a/cogs/curse_cog.py
+++ b/cogs/curse_cog.py
@@ -328,7 +328,9 @@ class CurseCog(commands.Cog):
                     "😼 Curse hurls the bucket into the air! A cloud of fent fills the room."
                 )
                 for character in ["Curse", "Bloom", "Grimm"]:
-                    await channel.send(random.choice(self.fent_party_success[character]))
+                    await channel.send(
+                        random.choice(self.fent_party_success[character])
+                    )
                 for member in guild.members:
                     if member.status == discord.Status.offline:
                         continue
@@ -341,7 +343,9 @@ class CurseCog(commands.Cog):
                             minutes = random.randint(1, 3)
                             await channel.send(
                                 f"{member.display_name} "
-                                + random.choice(self.fent_player_responses).format(minutes=minutes)
+                                + random.choice(self.fent_player_responses).format(
+                                    minutes=minutes
+                                )
                             )
             else:
                 await channel.send(f"{recipient.display_name} keeps the bucket...")
@@ -351,7 +355,9 @@ class CurseCog(commands.Cog):
                     minutes = random.randint(1, 3)
                     await channel.send(
                         f"{recipient.display_name} "
-                        + random.choice(self.fent_player_responses).format(minutes=minutes)
+                        + random.choice(self.fent_player_responses).format(
+                            minutes=minutes
+                        )
                     )
 
     @commands.Cog.listener()
@@ -441,7 +447,9 @@ class CurseCog(commands.Cog):
                         minutes = random.randint(1, 3)
                         await ctx.send(
                             f"{member.display_name} "
-                            + random.choice(self.fent_player_responses).format(minutes=minutes)
+                            + random.choice(self.fent_player_responses).format(
+                                minutes=minutes
+                            )
                         )
         elif outcome < 0.66:
             await ctx.send("😼 *purrs softly* Maybe I'll spare you... for now.")

--- a/cogs/cyberpunk_campaign_cog.py
+++ b/cogs/cyberpunk_campaign_cog.py
@@ -129,9 +129,7 @@ class CyberpunkCampaignCog(commands.Cog):
                 "You help a runaway droid evade capture, and it swears to repay the "
                 "favor someday."
             ),
-            (
-                "Curse chases off a swarm of pesky drones, clearing the path ahead."
-            ),
+            ("Curse chases off a swarm of pesky drones, clearing the path ahead."),
             (
                 "A hidden cache of neon graffiti supplies lets Bloom decorate the "
                 "streets with uplifting art."
@@ -173,9 +171,7 @@ class CyberpunkCampaignCog(commands.Cog):
                 "Curse tries to swipe a snack and angers a stall owner who calls "
                 "for backup."
             ),
-            (
-                "Bloom's humming attracts security drones that demand identification."
-            ),
+            ("Bloom's humming attracts security drones that demand identification."),
             (
                 "You hear rumors of a bounty on your heads spreading through the "
                 "undercity."
@@ -232,9 +228,7 @@ class CyberpunkCampaignCog(commands.Cog):
                 "Bloom hears a haunting melody that lures her toward a decrepit "
                 "theater rumored to be cursed."
             ),
-            (
-                "A rogue drone steals a valuable gadget right out of Grimm's hands."
-            ),
+            ("A rogue drone steals a valuable gadget right out of Grimm's hands."),
             (
                 "Street rumors point to a hidden trap ahead, but the only detour "
                 "leads through enemy turf."

--- a/cogs/grimm_cog.py
+++ b/cogs/grimm_cog.py
@@ -130,7 +130,9 @@ class GrimmCog(commands.Cog):
         guild = member.guild
         role = discord.utils.get(guild.roles, name="Grimm's Shield")
         if role is None:
-            role = await guild.create_role(name="Grimm's Shield", colour=discord.Colour.dark_gray())
+            role = await guild.create_role(
+                name="Grimm's Shield", colour=discord.Colour.dark_gray()
+            )
         try:
             await member.add_roles(role)
         except discord.Forbidden:

--- a/cogs/music_cog.py
+++ b/cogs/music_cog.py
@@ -97,7 +97,8 @@ class MusicCog(commands.Cog):
             await ctx.send("Queue is empty.")
             return
         msg = "Upcoming songs:\n" + "\n".join(
-            f"{idx + 1}. {item.get('title', 'unknown')}" for idx, item in enumerate(queue)
+            f"{idx + 1}. {item.get('title', 'unknown')}"
+            for idx, item in enumerate(queue)
         )
         await ctx.send(msg)
 

--- a/cogs/trivia_cog.py
+++ b/cogs/trivia_cog.py
@@ -5,11 +5,34 @@ from discord.ext import commands
 COG_VERSION = "1.3"
 
 NUMBER_WORDS = {
-    0: "zero", 1: "one", 2: "two", 3: "three", 4: "four", 5: "five", 6: "six",
-    7: "seven", 8: "eight", 9: "nine", 10: "ten", 11: "eleven", 12: "twelve",
-    13: "thirteen", 14: "fourteen", 15: "fifteen", 16: "sixteen", 17: "seventeen",
-    18: "eighteen", 19: "nineteen", 20: "twenty", 30: "thirty", 40: "forty",
-    50: "fifty", 60: "sixty", 70: "seventy", 80: "eighty", 90: "ninety",
+    0: "zero",
+    1: "one",
+    2: "two",
+    3: "three",
+    4: "four",
+    5: "five",
+    6: "six",
+    7: "seven",
+    8: "eight",
+    9: "nine",
+    10: "ten",
+    11: "eleven",
+    12: "twelve",
+    13: "thirteen",
+    14: "fourteen",
+    15: "fifteen",
+    16: "sixteen",
+    17: "seventeen",
+    18: "eighteen",
+    19: "nineteen",
+    20: "twenty",
+    30: "thirty",
+    40: "forty",
+    50: "fifty",
+    60: "sixty",
+    70: "seventy",
+    80: "eighty",
+    90: "ninety",
     100: "one hundred",
 }
 
@@ -33,24 +56,23 @@ class TriviaCog(commands.Cog):
         self.bot = bot
         self.questions = self._generate_questions(500)
         # add a few fixed general questions
-        self.questions.extend([
-            {
-                "question": "What is the capital of France?",
-                "answers": ["paris"]
-            },
-            {
-                "question": "Who wrote '1984'?",
-                "answers": ["george orwell", "orwell"]
-            },
-            {
-                "question": "What is the smallest prime number?",
-                "answers": ["2", "two"]
-            },
-            {
-                "question": "Which planet is known as the Red Planet?",
-                "answers": ["mars"]
-            },
-        ])
+        self.questions.extend(
+            [
+                {"question": "What is the capital of France?", "answers": ["paris"]},
+                {
+                    "question": "Who wrote '1984'?",
+                    "answers": ["george orwell", "orwell"],
+                },
+                {
+                    "question": "What is the smallest prime number?",
+                    "answers": ["2", "two"],
+                },
+                {
+                    "question": "Which planet is known as the Red Planet?",
+                    "answers": ["mars"],
+                },
+            ]
+        )
 
     def _generate_questions(self, count: int):
         questions = []
@@ -72,10 +94,9 @@ class TriviaCog(commands.Cog):
                 b = random.randint(1, 12)
                 question = f"What is {a} * {b}?"
                 ans = a * b
-            questions.append({
-                "question": question,
-                "answers": [str(ans), number_to_words(ans)]
-            })
+            questions.append(
+                {"question": question, "answers": [str(ans), number_to_words(ans)]}
+            )
         return questions
 
     @commands.command()

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -97,7 +97,9 @@ async def daily_gift():
         line = random.choice(positive_gift_responses)
     else:
         line = random.choice(negative_gift_responses)
-    await channel.send(f"🎁 {recipient.display_name}, " + line.format(gift=gift["name"]))
+    await channel.send(
+        f"🎁 {recipient.display_name}, " + line.format(gift=gift["name"])
+    )
 
 
 # === Curse Interactions ===

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -404,6 +404,7 @@ async def inventory(ctx):
     item = grimm_utils.random_item()
     await ctx.send(f"Grimm hands you {item}.")
 
+
 # === RANDOM PROTECTIVE RESPONSES ===
 
 

--- a/install.py
+++ b/install.py
@@ -109,7 +109,9 @@ def main() -> None:
     install_requirements()
     configure_env()
     choose_bot()
-    print("Congratulations. Your discord server is now cursed! That wasn't very smart of you…")
+    print(
+        "Congratulations. Your discord server is now cursed! That wasn't very smart of you…"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- run `black` for consistent formatting
- configure flake8 to ignore E203 and W503

## Testing
- `flake8 && echo "flake8 pass"`
- `black --check . && echo "black pass"`
- `python -m compileall -q . && echo "compileall pass"`


------
https://chatgpt.com/codex/tasks/task_e_68880c21bf248321aedf5db420a291cd