### PR TITLE
Add option to launch all bots from installer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,9 +61,9 @@ Prefer to get your paws dirty?
       - `OPENAI_API_KEY`
       Leave a value blank to keep any existing entry.
    4. **Choose bot** – finally you'll see a menu:
-      `1. GrimmBot`, `2. BloomBot`, `3. CurseBot`, `4. GoonBot`, `0. Exit`.
+      `1. GrimmBot`, `2. BloomBot`, `3. CurseBot`, `4. GoonBot`, `5. All bots`, `0. Exit`.
       Enter a number to launch a bot immediately or `0` to finish without
-      starting one.
+      starting one. Choosing option `5` launches all four bots at once.
 5. Launch any bot as shown above. All bots read from `config/setup.env`.
 
 Place optional media files in the `localtracks` directory.

--- a/install.py
+++ b/install.py
@@ -90,16 +90,33 @@ def choose_bot() -> None:
         "2": ("BloomBot", "bloom_bot.py"),
         "3": ("CurseBot", "curse_bot.py"),
         "4": ("GoonBot (all cogs)", "goon_bot.py"),
+        "5": ("All bots", None),
         "0": ("Exit", None),
     }
     for key, (name, _) in options.items():
         print(f" {key}. {name}")
-    choice = input("Run a bot now? [0-4] ").strip()
-    script = options.get(choice, (None, None))[1]
-    if script:
-        subprocess.call([sys.executable, script])
+    choice = input("Run a bot now? [0-5] ").strip()
+
+    if choice == "5":
+        scripts = ["grimm_bot.py", "bloom_bot.py", "curse_bot.py", "goon_bot.py"]
+        processes = [subprocess.Popen([sys.executable, s]) for s in scripts]
+        try:
+            for p in processes:
+                p.wait()
+        except KeyboardInterrupt:
+            print("\nStopping bots…")
+            for p in processes:
+                p.terminate()
+            for p in processes:
+                p.wait()
     else:
-        print("You can start a bot later using one of the python commands above.")
+        script = options.get(choice, (None, None))[1]
+        if script:
+            subprocess.call([sys.executable, script])
+        else:
+            print(
+                "You can start a bot later using one of the python commands above."
+            )
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- make installer able to start Grimm, Bloom, Curse and Goon bots together
- document the new menu option in INSTALL.md

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68881d59221883218e44c27082c31852