### PR TITLE
Enhance installer validation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The quick way is with the bootstrap script:
 bash <(curl -L https://raw.githubusercontent.com/The-w0rst/grimmbot/main/bootstrap.sh)
 ```
 
-Prefer manual control? Clone the repo and run `python install.py`. I'll ask for every token and set up `config/setup.env` for you. See [INSTALL.md](INSTALL.md) for a detailed walkthrough.
+Prefer manual control? Clone the repo and run `python install.py`. I'll ask for every token and set up `config/setup.env` for you. See [INSTALL.md](INSTALL.md) for a detailed walkthrough. If you're experimenting, create a test Discord server and generate bot tokens at <https://discord.com/developers>. Use those tokens in `config/setup.env` before launching a bot.
 
 ## Running the bots
 Once configured, pick a personality:

--- a/config/README.md
+++ b/config/README.md
@@ -20,8 +20,22 @@ at https://github.com/The-w0rst/grimmbot
    ```
 
    Open `config/setup.env` and fill in all the tokens and keys. Sections are grouped by bot
-   (Grimm, Bloom, Curse) and shared settings. Add `OPENAI_API_KEY` for ChatGPT
-   features or `SOCKET_SERVER_URL` if you want status reporting.
+(Grimm, Bloom, Curse) and shared settings. Add `OPENAI_API_KEY` for ChatGPT
+features or `SOCKET_SERVER_URL` if you want status reporting.
+
+### Environment variables
+
+| Variable | Description |
+| --- | --- |
+| `GRIMM_DISCORD_TOKEN` | Discord bot token for Grimm |
+| `GRIMM_API_KEY_1`-`GRIMM_API_KEY_3` | Custom API keys used by Grimm cogs |
+| `SOCKET_SERVER_URL` | Optional Socket.IO status endpoint |
+| `BLOOM_DISCORD_TOKEN` | Discord bot token for Bloom |
+| `BLOOM_API_KEY_1`-`BLOOM_API_KEY_3` | API keys for Bloom-specific features |
+| `CURSE_DISCORD_TOKEN` | Discord bot token for Curse |
+| `CURSE_API_KEY_1`-`CURSE_API_KEY_3` | API keys for Curse's cogs |
+| `DISCORD_TOKEN` | Token for the unified GoonBot |
+| `OPENAI_API_KEY` | Enables GPT-based commands |
 
 3. Save the file. Any bot you run will read these values automatically.
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,25 @@
+# flake8: noqa: E402
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from install import read_existing, validate_env
+
+
+def test_read_existing(tmp_path):
+    env = tmp_path / "sample.env"
+    env.write_text("A=1\nB=2\n#C=3\n")
+    assert read_existing(env) == {"A": "1", "B": "2"}
+
+
+def test_validate_env(tmp_path):
+    content = """GRIMM_DISCORD_TOKEN=123
+BLOOM_DISCORD_TOKEN=
+CURSE_DISCORD_TOKEN=abc
+DISCORD_TOKEN=
+"""
+    env = tmp_path / "vars.env"
+    env.write_text(content)
+    missing = validate_env(env)
+    assert set(missing) == {"BLOOM_DISCORD_TOKEN", "DISCORD_TOKEN"}


### PR DESCRIPTION
## Summary
- improve installer messaging and required token validation
- handle keyboard interrupts gracefully
- warn if required tokens remain blank
- document all environment variables
- add guidance on using test Discord servers
- add tests for installer helpers

## Testing
- `pip install -q -r requirements/extra-dev.txt`
- `python -m compileall -q .`
- `flake8`
- `pip check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688825e93c448321aa243ee5a0d576b5