### PR TITLE
Expand Bloom personality

### DIFF
--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -91,6 +91,11 @@ bloom_responses = [
     "Any excuse for a dance break, right?",
     "Glitter makes everything better, trust me!",
     "Let's turn this chat into a mini musical!",
+    "Musicals at midnight? Count me in!",
+    "Glitter here, glitter there, glitter everywhere!",
+    "Who wants to join my spontaneous karaoke?",
+    "I just hugged a pillow thinking it was you!",
+    "Boba first, questions later!",
 ]
 
 # Short help message used by the help commands
@@ -363,6 +368,30 @@ pretty_little_baby_lines = [
     "Pretty little baby, I'll always be true",
 ]
 
+comfort_lines = [
+    "Deep breaths, you've totally got this!",
+    "Bloom believes in you more than bubble tea!",
+    "Sending cuddles and sunshine your way!",
+    "You're stronger than you know, friend!",
+    "I'll stand by you with glittery support!",
+]
+
+story_lines = [
+    "Once upon a sparkle, you saved the day!",
+    "In a world of boba, you were the hero we needed.",
+    "There was a cat, a skeleton, and you—chaos ensued!",
+    "Legend tells of your epic dance moves across the land.",
+    "Every good story starts with a hug from Bloom!",
+]
+
+goodnight_lines = [
+    "Nighty night! Dream of bubble tea rivers!",
+    "May your dreams be filled with musicals and friends!",
+    "Sleep tight and don't let the glitter bite!",
+    "Rest well, tomorrow we'll cause more chaos!",
+    "Goodnight superstar, you deserve a break!",
+]
+
 # === Keyword Triggers ===
 keywords = {
     "grimm": ["Grimm is my spooky bestie.", "He acts tough, but he's a sweetheart."],
@@ -377,6 +406,10 @@ keywords = {
         "You're shining brighter than my glitter!",
         "Compliments inbound: you're amazing!",
     ],
+    "comfort": comfort_lines,
+    "story": story_lines,
+    "goodnight": goodnight_lines,
+    "gn": goodnight_lines,
     "queen": queen_lines,
     "girl": queen_lines,
     "girls": queen_lines,
@@ -592,6 +625,49 @@ async def boy(ctx):
 async def queen(ctx):
     """Share a playful yas queen-style line."""
     await ctx.send(random.choice(queen_lines))
+
+
+@bot.command()
+async def dance(ctx):
+    """Start a random dance party."""
+    moves = ["Cha-cha-cha!", "Time to boogie!", "Let's breakdance!"]
+    await ctx.send(random.choice(moves) + " 💃")
+
+
+@bot.command()
+async def sunshine(ctx):
+    """Shower the chat with sunshine."""
+    quotes = [
+        "Sunshine, lollipops, and rainbows!",
+        "You're my little ray of light!",
+        "Let's chase the clouds away!",
+    ]
+    await ctx.send(random.choice(quotes))
+
+
+@bot.command()
+async def flower(ctx):
+    """Share a virtual flower."""
+    flowers = ["🌸", "🌺", "🌷", "🌻", "💮"]
+    await ctx.send(random.choice(flowers) + " for you!")
+
+
+@bot.command()
+async def comfort(ctx):
+    """Offer supportive words."""
+    await ctx.send(random.choice(comfort_lines))
+
+
+@bot.command()
+async def story(ctx):
+    """Tell a short whimsical story."""
+    await ctx.send(random.choice(story_lines))
+
+
+@bot.command()
+async def goodnight(ctx):
+    """Say goodnight with flair."""
+    await ctx.send(random.choice(goodnight_lines))
 
 
 if not DISCORD_TOKEN:

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -41,6 +41,11 @@ class BloomCog(commands.Cog):
             "Pastel power incoming!",
             "Compliment break! You're awesome!",
             "Who needs sleep when we have each other?",
+            "Musicals at midnight? Count me in!",
+            "Glitter here, glitter there, glitter everywhere!",
+            "Who wants to join my spontaneous karaoke?",
+            "I just hugged a pillow thinking it was you!",
+            "Boba first, questions later!",
         ]
         self.boy_lines = [
             "Boy oh boy, let's have some fun!",
@@ -93,6 +98,11 @@ class BloomCog(commands.Cog):
             "Boy oh boy, let's throw a party!",
             "Hey boy, keep being amazing!",
             "Boys, let's conquer the day with joy!",
+            "Boy, you're rocking those vibes!",
+            "Boys, more jokes, less worries!",
+            "Boy oh boy, let's level up the fun!",
+            "Boys, let's spam Grimm with selfies!",
+            "Boy, keep shining like the star you are!",
         ]
         self.queen_lines = [
             "Yas queen! Slay the day!",
@@ -120,6 +130,11 @@ class BloomCog(commands.Cog):
             "Keep that crown polished, girl!",
             "Queens, let's turn up the glitter!",
             "You're royalty, girl—don't forget it!",
+            "Yas queen, strut your stuff!",
+            "Queens, bring on the sparkle storm!",
+            "Hey girl, your crown looks amazing today!",
+            "Queens rise above the drama!",
+            "Yas queen, keep slaying with kindness!",
         ]
         # Lines from Bloom's favorite song "Pretty Little Baby"
         self.pretty_little_baby_lines = [
@@ -129,6 +144,27 @@ class BloomCog(commands.Cog):
             "Pretty little baby, I'm hoping that you do",
             "Ask your mama, your papa, your sister or your brother",
             "If they've ever loved another like I love you",
+        ]
+        self.comfort_lines = [
+            "Deep breaths, you've totally got this!",
+            "Bloom believes in you more than bubble tea!",
+            "Sending cuddles and sunshine your way!",
+            "You're stronger than you know, friend!",
+            "I'll stand by you with glittery support!",
+        ]
+        self.story_lines = [
+            "Once upon a sparkle, you saved the day!",
+            "In a world of boba, you were the hero we needed.",
+            "There was a cat, a skeleton, and you—chaos ensued!",
+            "Legend tells of your epic dance moves across the land.",
+            "Every good story starts with a hug from Bloom!",
+        ]
+        self.goodnight_lines = [
+            "Nighty night! Dream of bubble tea rivers!",
+            "May your dreams be filled with musicals and friends!",
+            "Sleep tight and don't let the glitter bite!",
+            "Rest well, tomorrow we'll cause more chaos!",
+            "Goodnight superstar, you deserve a break!",
         ]
         self.user_interactions = {}
         self.gifts = [
@@ -210,6 +246,10 @@ class BloomCog(commands.Cog):
                 "You're shining brighter than my glitter!",
                 "Compliments inbound: you're amazing!",
             ],
+            "comfort": self.comfort_lines,
+            "story": self.story_lines,
+            "goodnight": self.goodnight_lines,
+            "gn": self.goodnight_lines,
             "queen": self.queen_lines,
             "girl": self.queen_lines,
             "girls": self.queen_lines,
@@ -444,6 +484,21 @@ class BloomCog(commands.Cog):
         """Share a virtual flower."""
         flowers = ["🌸", "🌺", "🌷", "🌻", "💮"]
         await ctx.send(random.choice(flowers) + " for you!")
+
+    @commands.command()
+    async def comfort(self, ctx):
+        """Offer supportive words."""
+        await ctx.send(random.choice(self.comfort_lines))
+
+    @commands.command()
+    async def story(self, ctx):
+        """Tell a short whimsical story."""
+        await ctx.send(random.choice(self.story_lines))
+
+    @commands.command()
+    async def goodnight(self, ctx):
+        """Say goodnight with flair."""
+        await ctx.send(random.choice(self.goodnight_lines))
 
 
 async def setup(bot: commands.Bot):


### PR DESCRIPTION
## Summary
- add more Bloom responses and spice up boy/queen lines
- extend keyword triggers for comfort, story and goodnight
- add new supportive and whimsical commands

## Testing
- `pip install -r requirements/base.txt`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68883925111483218ca9155f06dc6f12