### PR TITLE
Add README notes on how cogs load

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Hello, puny mortals. **Curse** speaking here. This repository holds me and my fe
 
 Each cog has a `COG_VERSION` for tracking updates. Check the [`docs`](docs) folder for deeper secrets.
 
+#### To Clarify the Cogs Section
+
+Cogs are modular command sets stored inside the `cogs/` directory. When you run
+`goon_bot.py`, every file that ends with `_cog.py` is loaded automatically.
+You can add or remove them at runtime using the Admin commands (`load`,
+`unload`, `reload`). For guidance on writing your own, see
+[`docs/creating_cogs.md`](docs/creating_cogs.md).
+
 ## Installation
 The quick way is with the bootstrap script:
 


### PR DESCRIPTION
## Summary
- add short section clarifying that cogs live in `cogs/` and are auto-loaded

## Testing
- `pip install -r requirements/extra-dev.txt`
- `pip install -r requirements/base.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688853edae9083219e644a009c33f318