### PR TITLE
Add simple logger utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ pip install -r requirements/extra-dev.txt
 pytest
 ```
 
+## Simple logging
+Use the helper in `src/logger.py` to print timestamped messages:
+
+```python
+from src.logger import log_message
+
+log_message("Bot starting up")
+```
+
 ## Developing your own chaos
 Peek at:
 

--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -20,6 +20,7 @@ from config.settings import load_config
 from pathlib import Path
 import yt_dlp
 import asyncio
+from src.logger import log_message
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -444,6 +445,7 @@ interactions = [
 @bot.event
 async def on_ready():
     logger.info("%s is online and ready to hug the whole server!", bloom_personality["name"])
+    log_message("Bloom bot ready")
 
 
 @bot.command(name="help")

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -5,6 +5,7 @@ import os
 import yt_dlp
 import asyncio
 from bloom_bot import perform_drama
+from src.logger import log_message
 
 COG_VERSION = "1.4"
 
@@ -345,7 +346,7 @@ class BloomCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        print("Bloom cog loaded.")
+        log_message("Bloom cog loaded.")
 
     @commands.Cog.listener()
     async def on_message(self, message):

--- a/cogs/curse_cog.py
+++ b/cogs/curse_cog.py
@@ -3,6 +3,7 @@ from discord.ext import commands, tasks
 import random
 import os
 import asyncio
+from src.logger import log_message
 
 COG_VERSION = "1.4"
 
@@ -362,7 +363,7 @@ class CurseCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        print("Curse cog loaded.")
+        log_message("Curse cog loaded.")
 
     @commands.Cog.listener()
     async def on_message(self, message):

--- a/cogs/grimm_cog.py
+++ b/cogs/grimm_cog.py
@@ -4,6 +4,7 @@ import random
 import os
 
 import socketio
+from src.logger import log_message
 
 COG_VERSION = "1.4"
 
@@ -18,14 +19,14 @@ sio = socketio.Client()
 try:
     sio.connect(SOCKET_SERVER)
 except Exception as e:
-    print(f"Failed to connect to Socket.IO dashboard: {e}")
+    log_message(f"Failed to connect to Socket.IO dashboard: {e}")
 
 
 def send_status(status, message):
     try:
         sio.emit("bot_status", {"bot": "Grimm", "status": status, "message": message})
     except Exception as e:
-        print(f"SocketIO error: {e}")
+        log_message(f"SocketIO error: {e}")
 
 
 class GrimmCog(commands.Cog):
@@ -148,7 +149,7 @@ class GrimmCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        print("Grimm cog loaded.")
+        log_message("Grimm cog loaded.")
         send_status("online", "On patrol. Nobody dies on my watch (except Mondays).")
 
     @commands.command()

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -17,6 +17,7 @@ import os
 import logging
 from config.settings import load_config
 from pathlib import Path
+from src.logger import log_message
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -397,6 +398,7 @@ fent_bot_responses = [
 @bot.event
 async def on_ready():
     logger.info("%s is here to ruin someone's day.", curse_personality["name"])
+    log_message("Curse bot ready")
     pick_daily_cursed.start()
     daily_gift.start()
 

--- a/goon_bot.py
+++ b/goon_bot.py
@@ -7,6 +7,7 @@ import discord
 from discord.ext import commands
 from pathlib import Path
 from config.settings import load_config
+from src.logger import log_message
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -34,6 +35,7 @@ bot = commands.Bot(command_prefix=get_prefix, intents=intents, help_command=None
 @bot.event
 async def on_ready():
     logger.info("Goon Bot online with cogs loaded.")
+    log_message("Goon bot ready")
 
 
 async def load_startup_cogs():

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -20,6 +20,7 @@ from config.settings import load_config
 import grimm_utils
 import random
 import socketio
+from src.logger import log_message
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -186,6 +187,7 @@ bot = commands.Bot(command_prefix="!", intents=intents, help_command=None)
 @bot.event
 async def on_ready():
     logger.info("Grimm has arrived. Watch your step, goons.")
+    log_message("Grimm bot ready")
     send_status("online", "On patrol. Nobody dies on my watch (except for Mondays).")
 
 

--- a/install.py
+++ b/install.py
@@ -6,6 +6,7 @@ in every token one by one with friendly descriptions. A few validation
 checks help guard against missing values."""
 import sys
 import logging
+from src.logger import log_message
 from colorama import Fore, Style, init
 
 # Project repository: https://github.com/The-w0rst/grimmbot
@@ -173,6 +174,7 @@ def choose_bot() -> None:
 
 def main() -> None:
     logger.info(CYAN + "== Goon Squad Bot Installer v%s ==" + RESET, VERSION)
+    log_message("Installer starting")
     logger.info("Curse here. I'll walk you through this. Let's do it!\n")
     try:
         check_python()

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,0 +1,7 @@
+from datetime import datetime
+
+
+def log_message(text: str) -> None:
+    """Print a timestamped log message."""
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{timestamp}] {text}")


### PR DESCRIPTION
## Summary
- create a `src/logger.py` module for timestamped print logging
- integrate `log_message` into bots and cogs
- log installer startup
- document logger usage in README

## Testing
- `pip install -r requirements/extra-dev.txt`
- `pip install -r requirements/base.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888579c8f908321b88f198c617aaa5f