### PR TITLE
Improve cog version handling

### DIFF
--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -2,5 +2,5 @@
 
 from pathlib import Path
 
-PACKAGE_VERSION = "1.4"
+PACKAGE_VERSION = "1.6"
 __all__ = [p.stem for p in Path(__file__).parent.glob("*_cog.py")]

--- a/cogs/admin_cog.py
+++ b/cogs/admin_cog.py
@@ -1,10 +1,9 @@
 from discord.ext import commands
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 
 class AdminCog(commands.Cog):
-    """Administration utilities for managing cogs. Version 1.4."""
+    """Administration utilities for managing cogs. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/announcement_cog.py
+++ b/cogs/announcement_cog.py
@@ -1,7 +1,6 @@
 import discord
 from discord.ext import commands, tasks
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 # Server reference information for quick access
 SERVER_ROLES = [
@@ -20,7 +19,7 @@ SERVER_CATEGORIES = {
 
 
 class AnnouncementCog(commands.Cog):
-    """Send periodic announcements and list server layout. Version 1.4."""
+    """Send periodic announcements and list server layout. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -6,8 +6,7 @@ import yt_dlp
 import asyncio
 from bloom_bot import perform_drama
 from src.logger import log_message
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 # Environment values are read from the parent process
 DISCORD_TOKEN = os.getenv("BLOOM_DISCORD_TOKEN")
@@ -18,7 +17,7 @@ EPIC_VIDEO_URL = "https://m.youtube.com/watch?v=6K-eMKjo1bs"
 
 
 class BloomCog(commands.Cog):
-    """BloomBot personality packaged as a Cog. Version 1.4."""
+    """BloomBot personality packaged as a Cog. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/curse_cog.py
+++ b/cogs/curse_cog.py
@@ -4,8 +4,7 @@ import random
 import os
 import asyncio
 from src.logger import log_message
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 # Environment values are read from the parent process
 DISCORD_TOKEN = os.getenv("CURSE_DISCORD_TOKEN")
@@ -22,7 +21,7 @@ def is_protected(member: discord.Member) -> bool:
 
 
 class CurseCog(commands.Cog):
-    """CurseBot personality packaged as a Cog. Version 1.4."""
+    """CurseBot personality packaged as a Cog. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/cyberpunk_campaign_cog.py
+++ b/cogs/cyberpunk_campaign_cog.py
@@ -2,8 +2,7 @@ import os
 import random
 import openai
 from discord.ext import commands
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 # Environment values are read from the parent process
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -11,7 +10,7 @@ openai.api_key = OPENAI_API_KEY
 
 
 class CyberpunkCampaignCog(commands.Cog):
-    """Cyberpunk themed mini DnD campaign with simple character sheets. Version 1.4."""
+    """Cyberpunk themed mini DnD campaign with simple character sheets. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/fun_cog.py
+++ b/cogs/fun_cog.py
@@ -1,11 +1,10 @@
 from discord.ext import commands
 import random
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 
 class FunCog(commands.Cog):
-    """Random fun commands like dice rolls and an 8-ball. Version 1.4."""
+    """Random fun commands like dice rolls and an 8-ball. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/goon_cog.py
+++ b/cogs/goon_cog.py
@@ -1,11 +1,10 @@
 import random
 from discord.ext import commands
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 
 class GoonCog(commands.Cog):
-    """Group lines from all bots together. Version 1.4."""
+    """Group lines from all bots together. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/gpt_cog.py
+++ b/cogs/gpt_cog.py
@@ -1,8 +1,7 @@
 import os
 import openai
 from discord.ext import commands
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 # Environment values are read from the parent process
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -16,7 +15,7 @@ SYSTEM_MESSAGES = {
 
 
 class GPTCog(commands.Cog):
-    """Cog that adds a ChatGPT-based chat command and mention replies. Version 1.4."""
+    """Cog that adds a ChatGPT-based chat command and mention replies. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/grimm_cog.py
+++ b/cogs/grimm_cog.py
@@ -5,8 +5,7 @@ import os
 
 import socketio
 from src.logger import log_message
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 # Environment values are read from the parent process
 DISCORD_TOKEN = os.getenv("GRIMM_DISCORD_TOKEN")
@@ -30,7 +29,7 @@ def send_status(status, message):
 
 
 class GrimmCog(commands.Cog):
-    """GrimmBot personality packaged as a Cog. Version 1.4."""
+    """GrimmBot personality packaged as a Cog. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/grimm_extra_cog.py
+++ b/cogs/grimm_extra_cog.py
@@ -2,13 +2,11 @@ import discord
 from discord.ext import commands
 
 
-from . import grimm_utils
-
-COG_VERSION = "1.4"
+from . import grimm_utils, PACKAGE_VERSION as COG_VERSION
 
 
 class GrimmExtraCog(commands.Cog):
-    """Additional utilities and fun commands for Grimm. Version 1.4."""
+    """Additional utilities and fun commands for Grimm. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/help_cog.py
+++ b/cogs/help_cog.py
@@ -1,6 +1,5 @@
 from discord.ext import commands
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 # Short help messages for each bot so they can be reused in other commands
 GRIMM_HELP = (
@@ -20,7 +19,7 @@ CURSE_HELP = (
 
 
 class HelpCog(commands.Cog):
-    """Provide help commands for the goons. Version 1.4."""
+    """Provide help commands for the goons. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/jojo_cog.py
+++ b/cogs/jojo_cog.py
@@ -3,14 +3,14 @@ import discord
 import datetime
 import random
 
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 JOJO_DISPLAY_NAME = "JoJo is bizarre"
 EMMA_NAME = "Emma"
 
 
 class JojoCog(commands.Cog):
-    """Send spontaneous loving messages to Emma. Version 1.4."""
+    """Send spontaneous loving messages to Emma. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/moderation_cog.py
+++ b/cogs/moderation_cog.py
@@ -1,11 +1,10 @@
 import discord
 from discord.ext import commands
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 
 class ModerationCog(commands.Cog):
-    """Basic moderation commands. Version 1.4."""
+    """Basic moderation commands. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/music_cog.py
+++ b/cogs/music_cog.py
@@ -6,11 +6,11 @@ import requests
 from bs4 import BeautifulSoup
 from typing import Dict, List
 
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 
 class MusicCog(commands.Cog):
-    """Basic music playback commands with queue support. Version 1.4."""
+    """Basic music playback commands with queue support. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/cogs/trivia_cog.py
+++ b/cogs/trivia_cog.py
@@ -1,8 +1,7 @@
 import random
 import asyncio
 from discord.ext import commands
-
-COG_VERSION = "1.4"
+from . import PACKAGE_VERSION as COG_VERSION
 
 NUMBER_WORDS = {
     0: "zero",
@@ -50,7 +49,7 @@ def number_to_words(n: int) -> str:
 
 
 class TriviaCog(commands.Cog):
-    """Randomized trivia game with 500 math questions. Version 1.4."""
+    """Randomized trivia game with 500 math questions. Version 1.6."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot

--- a/configure.py
+++ b/configure.py
@@ -7,7 +7,7 @@ import logging
 
 TEMPLATE_PATH = Path("config/env_template.env")
 SETUP_PATH = Path("config/setup.env")
-VERSION = "1.4"
+VERSION = "1.6"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- centralize cog version in `cogs.__init__`
- reference `PACKAGE_VERSION` constant from each cog
- bump cog docs and config helper to version 1.6

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888621688bc8321b5315e2e3cbab65e