### PR TITLE
Enhance judge logic & add diagnostics docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ Hello, puny mortals. **Curse** speaking here. This repository holds me and my fe
    ```
    This grabs the repo, installs dependencies and launches the installer.
 2. Provide your Discord tokens and API keys when asked. They will be saved to `config/setup.env`.
-3. Start any of the bots:
+3. Run the optional diagnostics script to verify your environment:
+   ```bash
+   python diagnostics.py
+   ```
+   It checks for missing files, packages and variables before you launch a bot.
+4. Start any of the bots:
    ```bash
   python grimm_bot.py   # or bloom_bot.py, curse_bot.py, goon_bot.py
   ```

--- a/docs/cogs_overview.md
+++ b/docs/cogs_overview.md
@@ -19,6 +19,7 @@ what mischief it adds. All cogs are currently **v1.6**.
 | `cyberpunk_campaign_cog.py` | Lightweight cyberpunk themed DnD campaign using ChatGPT. See [cyberpunk_adventure.md](cyberpunk_adventure.md) for expanded scenarios. |
 | `help_cog.py` | Provides `help` commands for each bot and a `helpall` summary. |
 | `goon_cog.py` | The whole squad chiming in together. |
+| `judge_cog.py` | Simple relationship judge that lets the squad weigh in via DM. |
 
 All cogs declare a `COG_VERSION` constant for easy tracking of updates. Load them one by one with `goon_bot.py` or the Admin commands.
 For music playback details see [`music_setup.md`](music_setup.md).

--- a/tests/test_judge_cog.py
+++ b/tests/test_judge_cog.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from discord.ext import commands
+import discord
+from cogs.judge_cog import JudgeCog
+
+
+def test_decide_vote_positive():
+    intents = discord.Intents.default()
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = JudgeCog(bot)
+    vote = cog._decide_vote("I am sorry please help", "You are awful")
+    assert vote == "User1"
+
+
+def test_decide_vote_tie():
+    intents = discord.Intents.default()
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = JudgeCog(bot)
+    vote = cog._decide_vote("Ok", "Okay")
+    assert vote == "Both should compromise"


### PR DESCRIPTION
## Summary
- expand `judge_cog` with keyword-weighted scoring
- document new `judge_cog` in the cog overview
- mention diagnostics script in README quickstart
- add regression tests for judge scoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688874f0a9688321b334eeb85508215e