### PR TITLE
Fix flake8 E402 in judge cog test

### DIFF
--- a/tests/test_judge_cog.py
+++ b/tests/test_judge_cog.py
@@ -1,3 +1,5 @@
+
+# flake8: noqa: E402
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- prevent flake8 E402 errors in `tests/test_judge_cog.py`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688878139940832196ec08eba177a995