### PR TITLE
Fix pep8 issue in judge_cog

### DIFF
--- a/cogs/judge_cog.py
+++ b/cogs/judge_cog.py
@@ -27,6 +27,7 @@ REASONS = {
     "Both should compromise": "Neither side convinced me completely.",
 }
 
+
 POSITIVE_WORDS = {
     "please",
     "thank",


### PR DESCRIPTION
## Summary
- insert missing blank line before `POSITIVE_WORDS` to silence flake8

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688878481e808321803abe9b78ecfcbf