### PR TITLE
Fix flake8 and update test imports

### DIFF
--- a/cogs/health_cog.py
+++ b/cogs/health_cog.py
@@ -3,6 +3,7 @@ from src import health
 
 COG_VERSION = "1.0"
 
+
 class HealthCog(commands.Cog):
     """Shared health menu commands."""
 
@@ -13,6 +14,7 @@ class HealthCog(commands.Cog):
     async def health_cmd(self, ctx: commands.Context):
         """Show current health for all bots."""
         await ctx.send(health.get_menu())
+
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(HealthCog(bot))

--- a/tests/test_judge_cog.py
+++ b/tests/test_judge_cog.py
@@ -1,4 +1,3 @@
-
 # flake8: noqa: E402
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary
- fix flake8 errors for HealthCog
- place `flake8: noqa` at start of `test_judge_cog`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688879c58f3c8321ae013785efc04b60