### PR TITLE
Format files and ensure style

### DIFF
--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -514,8 +514,12 @@ async def on_ready():
     guilds = ", ".join(g.name for g in bot.guilds)
     cogs = ", ".join(bot.cogs.keys())
     env = {
-        "BLOOM_DISCORD_TOKEN": (DISCORD_TOKEN[:4] + "...") if DISCORD_TOKEN else "missing",
-        "BLOOM_OPENAI_KEY": (BLOOM_OPENAI_KEY[:4] + "...") if BLOOM_OPENAI_KEY else "missing",
+        "BLOOM_DISCORD_TOKEN": (
+            (DISCORD_TOKEN[:4] + "...") if DISCORD_TOKEN else "missing"
+        ),
+        "BLOOM_OPENAI_KEY": (
+            (BLOOM_OPENAI_KEY[:4] + "...") if BLOOM_OPENAI_KEY else "missing"
+        ),
     }
     logger.info("Bloom online | guilds: %s | cogs: %s | env: %s", guilds, cogs, env)
     log_message("Bloom bot ready")

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -474,8 +474,12 @@ async def on_ready():
     guilds = ", ".join(g.name for g in bot.guilds)
     cogs = ", ".join(bot.cogs.keys())
     env = {
-        "CURSE_DISCORD_TOKEN": (DISCORD_TOKEN[:4] + "...") if DISCORD_TOKEN else "missing",
-        "CURSE_OPENAI_KEY": (CURSE_OPENAI_KEY[:4] + "...") if CURSE_OPENAI_KEY else "missing",
+        "CURSE_DISCORD_TOKEN": (
+            (DISCORD_TOKEN[:4] + "...") if DISCORD_TOKEN else "missing"
+        ),
+        "CURSE_OPENAI_KEY": (
+            (CURSE_OPENAI_KEY[:4] + "...") if CURSE_OPENAI_KEY else "missing"
+        ),
     }
     logger.info("Curse online | guilds: %s | cogs: %s | env: %s", guilds, cogs, env)
     log_message("Curse bot ready")

--- a/goon_bot.py
+++ b/goon_bot.py
@@ -26,6 +26,7 @@ def check_required() -> None:
         logger.error("DISCORD_TOKEN missing")
         raise SystemExit(1)
 
+
 # Allow '!', '*', and '?' prefixes like the individual bots
 
 

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -209,10 +209,16 @@ async def on_ready():
     guilds = ", ".join(g.name for g in bot.guilds)
     cogs = ", ".join(bot.cogs.keys())
     env_summary = {
-        "GRIMM_DISCORD_TOKEN": (DISCORD_TOKEN[:4] + "...") if DISCORD_TOKEN else "missing",
-        "GRIMM_OPENAI_KEY": (GRIMM_OPENAI_KEY[:4] + "...") if GRIMM_OPENAI_KEY else "missing",
+        "GRIMM_DISCORD_TOKEN": (
+            (DISCORD_TOKEN[:4] + "...") if DISCORD_TOKEN else "missing"
+        ),
+        "GRIMM_OPENAI_KEY": (
+            (GRIMM_OPENAI_KEY[:4] + "...") if GRIMM_OPENAI_KEY else "missing"
+        ),
     }
-    logger.info("Grimm online | guilds: %s | cogs: %s | env: %s", guilds, cogs, env_summary)
+    logger.info(
+        "Grimm online | guilds: %s | cogs: %s | env: %s", guilds, cogs, env_summary
+    )
     log_message("Grimm bot ready")
     send_status("online", "On patrol. Nobody dies on my watch (except for Mondays).")
 

--- a/install.py
+++ b/install.py
@@ -102,6 +102,7 @@ def configure_env() -> None:
         if key.startswith("CURSE"):
             return ORANGE
         return YELLOW
+
     friendly = {
         "GRIMM_DISCORD_TOKEN": "Grimm's Discord token",
         "GRIMM_API_KEY_1": "Grimm API key #1",


### PR DESCRIPTION
## Summary
- run `black` on bot entrypoints and installer for consistent style
- no logic changes; flake8 clean

## Testing
- `flake8 --count`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688881e366f48321a4ac42dbed3761bf