### PR TITLE
Improve color-coded prompts

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,6 +13,7 @@ Welcome to the first public release of the Goon Squad bots.
    ```
    It clones the repo, installs dependencies, and starts the installer. On Windows run `py -3 install.py` after cloning instead.
 3. Run the installer and hand over your Discord tokens and API keys when Curse asks. The prompts are color coded for clarity and everything is saved to `config/setup.env`.
+   The colors match each bot: **Grimm** in blue, **Bloom** in orange and **Curse** in red.
 4. Start a bot of your choice:
    ```bash
    python grimm_bot.py   # or bloom_bot.py, curse_bot.py, goon_bot.py
@@ -31,9 +32,9 @@ Prefer to get your paws dirty?
    pip install -r requirements/base.txt
    ```
    Optional developer extras are in `requirements/extra-dev.txt`.
-   The `setup.sh` helper installs from `requirements.txt` instead, which
-   includes the base packages plus `requests` and `beautifulsoup4` for the
-   music cog.
+  The `setup.sh` helper installs from `requirements.txt` instead. That file
+  includes the same base packages plus `requests`, `beautifulsoup4`, and
+  `colorama` for the music cog and colorful prompts.
 3. Install FFmpeg if you plan to use the music commands. See
    [`docs/music_setup.md`](docs/music_setup.md) for OS-specific commands.
 4. Copy the environment template and fill it in:
@@ -43,6 +44,7 @@ Prefer to get your paws dirty?
    On Windows use `copy` instead of `cp`. Fill in your Discord tokens and API
    keys.
 5. Run `python install.py` and follow Curse's friendly, color-coded prompts.
+   Grimm's prompts appear in blue, Bloom's in orange and Curse's in red.
    The installer guides you through four steps:
    1. **Python check** – verifies you're running Python 3.10 or newer.
    2. **Dependencies** – when asked `Install dependencies now? [Y/n]` press

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ I'll ask for every token with bright prompts and set up:
 config/setup.env
 ```
 
+### Prompt colors
+The installer and setup tools use consistent colors to show which bot is
+speaking:
+
+- **Grimm** – blue
+- **Bloom** – orange
+- **Curse** – red
+
 See `INSTALL.md` for a detailed walkthrough. If you're experimenting, create a test Discord server and generate bot tokens at <https://discord.com/developers>. Use those tokens in:
 
 ```

--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -22,10 +22,14 @@ from config.settings import load_config
 from pathlib import Path
 import yt_dlp
 from src.logger import setup_logging, log_message
+from colorama import Fore, Style, init
 
 # Configure logging
 setup_logging("bloom_bot.log")
 logger = logging.getLogger(__name__)
+init(autoreset=True)
+ORANGE = Fore.LIGHTYELLOW_EX + Style.BRIGHT
+RESET = Style.RESET_ALL
 
 # Load a single shared configuration file for all bots
 ENV_PATH = Path(__file__).resolve().parent / "config" / "setup.env"
@@ -498,7 +502,9 @@ async def _collect_statement(member: discord.Member, issue: str) -> str | None:
 @bot.event
 async def on_ready():
     logger.info(
-        "%s is online and ready to hug the whole server!", bloom_personality["name"]
+        ORANGE
+        + f"{bloom_personality['name']} is online and ready to hug the whole server!"
+        + RESET
     )
     log_message("Bloom bot ready")
 

--- a/configure.py
+++ b/configure.py
@@ -2,6 +2,7 @@
 """Interactive configuration helper for the Goon Squad bots."""
 from pathlib import Path
 import logging
+from colorama import Fore, Style, init
 
 # Project repository: https://github.com/The-w0rst/grimmbot
 
@@ -11,6 +12,12 @@ VERSION = "1.4"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+init(autoreset=True)
+BLUE = Fore.LIGHTBLUE_EX + Style.BRIGHT
+ORANGE = Fore.LIGHTYELLOW_EX + Style.BRIGHT
+RED = Fore.LIGHTRED_EX + Style.BRIGHT
+YELLOW = Fore.YELLOW + Style.BRIGHT
+RESET = Style.RESET_ALL
 
 
 def read_existing(path: Path) -> dict:
@@ -22,6 +29,16 @@ def read_existing(path: Path) -> dict:
             key, value = line.split("=", 1)
             data[key.strip()] = value.strip()
     return data
+
+
+def get_color(key: str) -> str:
+    if key.startswith("GRIMM_"):
+        return BLUE
+    if key.startswith("BLOOM_"):
+        return ORANGE
+    if key.startswith("CURSE_"):
+        return RED
+    return YELLOW
 
 
 def main() -> None:
@@ -37,6 +54,8 @@ def main() -> None:
         key = line.split("=", 1)[0]
         default = existing.get(key, "")
         prompt = f"{key} [{default}]: " if default else f"{key}: "
+        color = get_color(key)
+        prompt = color + prompt + RESET
         value = input(prompt).strip() or default
         lines.append(f"{key}={value}")
     SETUP_PATH.write_text("\n".join(lines) + "\n")

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -16,6 +16,7 @@ import random
 import os
 import asyncio
 import openai
+from colorama import Fore, Style, init
 import logging
 from config.settings import load_config
 from pathlib import Path
@@ -24,6 +25,9 @@ from src.logger import setup_logging, log_message
 # Configure logging
 setup_logging("curse_bot.log")
 logger = logging.getLogger(__name__)
+init(autoreset=True)
+RED = Fore.LIGHTRED_EX + Style.BRIGHT
+RESET = Style.RESET_ALL
 
 # Load a single shared configuration file for all bots
 ENV_PATH = Path(__file__).resolve().parent / "config" / "setup.env"
@@ -457,7 +461,9 @@ async def _collect_statement(member: discord.Member, issue: str) -> str | None:
 
 @bot.event
 async def on_ready():
-    logger.info("%s is here to ruin someone's day.", curse_personality["name"])
+    logger.info(
+        RED + f"{curse_personality['name']} is here to ruin someone's day." + RESET
+    )
     log_message("Curse bot ready")
     pick_daily_cursed.start()
     daily_gift.start()

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -16,6 +16,7 @@ from discord.ext import commands
 import os
 import asyncio
 import openai
+from colorama import Fore, Style, init
 
 import logging
 from config.settings import load_config
@@ -23,6 +24,11 @@ import grimm_utils
 import random
 import socketio
 from src.logger import setup_logging, log_message
+
+# Setup color output
+init(autoreset=True)
+BLUE = Fore.LIGHTBLUE_EX + Style.BRIGHT
+RESET = Style.RESET_ALL
 
 # Configure logging
 setup_logging("grimm_bot.log")
@@ -191,7 +197,7 @@ bot = commands.Bot(command_prefix="!", intents=intents, help_command=None)
 
 @bot.event
 async def on_ready():
-    logger.info("Grimm has arrived. Watch your step, goons.")
+    logger.info(BLUE + "Grimm has arrived. Watch your step, goons." + RESET)
     log_message("Grimm bot ready")
     send_status("online", "On patrol. Nobody dies on my watch (except for Mondays).")
 

--- a/install.py
+++ b/install.py
@@ -21,7 +21,9 @@ init(autoreset=True)
 CYAN = Fore.CYAN + Style.BRIGHT
 GREEN = Fore.GREEN + Style.BRIGHT
 YELLOW = Fore.YELLOW + Style.BRIGHT
-RED = Fore.RED + Style.BRIGHT
+RED = Fore.LIGHTRED_EX + Style.BRIGHT
+BLUE = Fore.LIGHTBLUE_EX + Style.BRIGHT
+ORANGE = Fore.LIGHTYELLOW_EX + Style.BRIGHT
 RESET = Style.RESET_ALL
 
 VERSION = "1.5"
@@ -37,6 +39,16 @@ REQUIRED_VARS = {
     "CURSE_DISCORD_TOKEN",
     "DISCORD_TOKEN",
 }
+
+
+def get_color(key: str) -> str:
+    if key.startswith("GRIMM_"):
+        return BLUE
+    if key.startswith("BLOOM_"):
+        return ORANGE
+    if key.startswith("CURSE_"):
+        return RED
+    return YELLOW
 
 
 def read_existing(path: Path) -> dict:
@@ -83,7 +95,11 @@ def install_requirements() -> None:
 def configure_env() -> None:
     logger.info(
         CYAN
-        + "Step 3/4: Time to hand over the keys. I'm Curse and I'll keep them safe!"
+        + "Step 3/4: Time to hand over the keys. I'm "
+        + RED
+        + "Curse"
+        + CYAN
+        + " and I'll keep them safe!"
         + RESET
     )
     TEMPLATE_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -117,7 +133,8 @@ def configure_env() -> None:
         desc = friendly.get(key, key)
         default = existing.get(key, "")
         prompt = f"{desc} [{default}]: " if default else f"{desc}: "
-        prompt = YELLOW + prompt + RESET
+        color = get_color(key)
+        prompt = color + prompt + RESET
         while True:
             try:
                 value = input(prompt).strip() or default
@@ -157,8 +174,16 @@ def choose_bot() -> None:
         "5": ("All bots", None),
         "0": ("Exit", None),
     }
+    color_map = {
+        "GrimmBot": BLUE,
+        "BloomBot": ORANGE,
+        "CurseBot": RED,
+        "GoonBot (all cogs)": CYAN,
+        "All bots": GREEN,
+    }
     for key, (name, _) in options.items():
-        logger.info(" %s. %s", key, name)
+        color = color_map.get(name, YELLOW)
+        logger.info(color + " %s. %s" + RESET, key, name)
     try:
         choice = input(YELLOW + "Run a bot now? [0-5] " + RESET).strip()
     except KeyboardInterrupt:
@@ -190,7 +215,9 @@ def choose_bot() -> None:
 def main() -> None:
     logger.info(CYAN + "== Goon Squad Bot Installer v%s ==" + RESET, VERSION)
     log_message("Installer starting")
-    logger.info("Curse here. I'll walk you through this. Let's do it!\n")
+    logger.info(
+        RED + "Curse" + RESET + " here. I'll walk you through this. Let's do it!\n"
+    )
     try:
         check_python()
         install_requirements()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ yt_dlp
 lavalink
 requests
 beautifulsoup4
+colorama==0.4.6


### PR DESCRIPTION
## Summary
- colorize config prompts per character in `install.py` and `configure.py`
- highlight startup messages for Grimm, Bloom and Curse with their colors
- document the color scheme in `README.md` and `INSTALL.md`
- color entire Grimm startup log line
- include colorama in general requirements

## Testing
- `pip install -r requirements/base.txt`
- `pip install -r requirements/extra-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68887f96ef5c8321ac3ff32bd81a50ea