### PR TITLE
Add Colorama-based console logging

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,6 +43,7 @@ Prefer to get your paws dirty?
    On Windows use `copy` instead of `cp`. Fill in your Discord tokens and API
    keys.
 5. Run `python install.py` and follow Curse's friendly, color-coded prompts.
+   The installer installs `colorama` automatically so the colors work on any system.
    The installer guides you through four steps:
    1. **Python check** – verifies you're running Python 3.10 or newer.
    2. **Dependencies** – when asked `Install dependencies now? [Y/n]` press

--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ bloom_bot.py – Bloom the bubbly chaos (* prefix)
 curse_bot.py – yours truly (? prefix)
 goon_bot.py – load every cog at once
 cogs/ – trivia, moderation, music and more
-install.py – interactive installer with my charming narration and colorful prompts
+install.py – interactive installer with my charming narration and colorful prompts (via Colorama)
 ```
+
+The installer installs the `colorama` package automatically so the prompts and
+log output show up in vivid hues on any platform.
 
 Each cog has a `COG_VERSION` for tracking updates. Check the [`docs`](docs) folder for deeper secrets.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ python-socketio==5.13.0
 openai==1.97.1
 yt_dlp
 lavalink
+colorama
 requests
 beautifulsoup4

--- a/src/logger.py
+++ b/src/logger.py
@@ -3,16 +3,50 @@
 import logging
 from logging.handlers import RotatingFileHandler
 
+try:
+    from colorama import Fore, Style, init as colorama_init
+except Exception:  # pragma: no cover - colorama optional for tests
+    Fore = Style = None
+    def colorama_init(*_args, **_kwargs):
+        return
+
 
 def setup_logging(log_file: str = "bot.log") -> None:
-    """Configure the logging module to write timestamped messages."""
-    handler = RotatingFileHandler(log_file, maxBytes=1024 * 1024, backupCount=3)
-    formatter = logging.Formatter(
+    """Configure logging with file and colorized console handlers."""
+    colorama_init(autoreset=True)
+
+    file_handler = RotatingFileHandler(log_file, maxBytes=1024 * 1024, backupCount=3)
+    file_formatter = logging.Formatter(
         "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
-    handler.setFormatter(formatter)
-    logging.basicConfig(level=logging.INFO, handlers=[handler])
+    file_handler.setFormatter(file_formatter)
+
+    console_handler = logging.StreamHandler()
+    if Fore and Style:
+        class ColorFormatter(logging.Formatter):
+            COLORS = {
+                logging.DEBUG: Fore.CYAN,
+                logging.INFO: Fore.GREEN,
+                logging.WARNING: Fore.YELLOW,
+                logging.ERROR: Fore.RED,
+                logging.CRITICAL: Fore.MAGENTA,
+            }
+
+            def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - visual only
+                color = self.COLORS.get(record.levelno, "")
+                message = super().format(record)
+                return f"{color}{message}{Style.RESET_ALL}"
+
+        console_formatter = ColorFormatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s", datefmt="%H:%M:%S")
+    else:  # pragma: no cover - fallback for tests
+        console_formatter = logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
+    console_handler.setFormatter(console_formatter)
+
+    logging.basicConfig(level=logging.INFO, handlers=[file_handler, console_handler])
 
 
 def log_message(text: str, level: int = logging.INFO) -> None:


### PR DESCRIPTION
## Summary
- colorize log output using Colorama in `src/logger.py`
- install Colorama when using `requirements.txt`
- document new color logging in README and INSTALL guides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688884e6ac4c83219e497766e1482c6b