### PR TITLE
Add docs for color logging and fix flake8

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ from src.logger import log_message
 
 log_message("Bot starting up")
 ```
+The console output is colorized when `colorama` is available (installed
+automatically by `install.py`). Log files are still plain text.
 
 ## Developing your own chaos
 Peek at:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,3 +8,6 @@
 - Improved error handling and startup diagnostics.
 - Added health command and runtime checks for missing tokens.
 - Updated installer with color-coded prompts.
+
+## v1.8
+- Added colorized console logging via `src/logger.py`.

--- a/docs/creating_cogs.md
+++ b/docs/creating_cogs.md
@@ -29,3 +29,12 @@ async def setup(bot):
 
 That's all there is to it. Keep your cogs small and focused, and bump the
 `COG_VERSION` constant if you make updates.
+
+### Logging from your cog
+Import `log_message` and sprinkle it around to see colored logs in the console:
+
+```python
+from src.logger import log_message
+
+log_message("MyCog loaded")
+```

--- a/src/logger.py
+++ b/src/logger.py
@@ -7,6 +7,7 @@ try:
     from colorama import Fore, Style, init as colorama_init
 except Exception:  # pragma: no cover - colorama optional for tests
     Fore = Style = None
+
     def colorama_init(*_args, **_kwargs):
         return
 


### PR DESCRIPTION
## Summary
- document colorized console output in README and creating cogs docs
- note color logging update in CHANGELOG
- silence flake8 error in logger setup

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688886e2d4448321bb53c6f7178c4d82