### PR TITLE
Ensure consistent formatting and pinned deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ discord.py==2.5.2
 python-dotenv==1.1.1
 python-socketio==5.13.0
 openai==1.97.1
-yt_dlp
-lavalink
-colorama
+yt_dlp==2024.3.10
+lavalink==5.9.0
+colorama==0.4.6
 requests
 beautifulsoup4

--- a/src/logger.py
+++ b/src/logger.py
@@ -25,6 +25,7 @@ def setup_logging(log_file: str = "bot.log") -> None:
 
     console_handler = logging.StreamHandler()
     if Fore and Style:
+
         class ColorFormatter(logging.Formatter):
             COLORS = {
                 logging.DEBUG: Fore.CYAN,
@@ -34,12 +35,16 @@ def setup_logging(log_file: str = "bot.log") -> None:
                 logging.CRITICAL: Fore.MAGENTA,
             }
 
-            def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - visual only
+            def format(
+                self, record: logging.LogRecord
+            ) -> str:  # pragma: no cover - visual only
                 color = self.COLORS.get(record.levelno, "")
                 message = super().format(record)
                 return f"{color}{message}{Style.RESET_ALL}"
 
-        console_formatter = ColorFormatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s", datefmt="%H:%M:%S")
+        console_formatter = ColorFormatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s", datefmt="%H:%M:%S"
+        )
     else:  # pragma: no cover - fallback for tests
         console_formatter = logging.Formatter(
             "%(asctime)s [%(levelname)s] %(name)s: %(message)s",


### PR DESCRIPTION
## Summary
- format `src/logger.py` with black
- pin versions in `requirements.txt` for consistent installs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68888bef52688321a015518dd62043ee