### PR TITLE
Add env generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ config/setup.env
 
 before launching a bot. A full list of variables is documented in `config/README.md`.
 
+For automated setups (CI, Docker, etc.) you can create the environment file from
+existing variables with:
+
+```bash
+python generate_env.py
+```
+
 ### Dependencies
 All required Python packages live in:
 

--- a/config/README.md
+++ b/config/README.md
@@ -23,6 +23,15 @@ at https://github.com/The-w0rst/grimmbot
 (Grimm, Bloom, Curse) and shared settings. Add `OPENAI_API_KEY` for ChatGPT
 features or `SOCKET_SERVER_URL` if you want status reporting.
 
+3. For automated environments you can generate the file from existing shell
+   variables:
+
+   ```bash
+   python generate_env.py
+   ```
+
+   Each entry in the template is filled with the matching environment variable.
+
 ### Environment variables
 
 | Variable | Description |

--- a/generate_env.py
+++ b/generate_env.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Create config/setup.env from current environment variables."""
+from pathlib import Path
+import os
+
+TEMPLATE_PATH = Path('config/env_template.env')
+OUTPUT_PATH = Path('config/setup.env')
+
+
+def main() -> None:
+    lines = []
+    for line in TEMPLATE_PATH.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#') or '=' not in line:
+            lines.append(line)
+            continue
+        key = line.split('=', 1)[0]
+        value = os.getenv(key, '')
+        lines.append(f"{key}={value}")
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text('\n'.join(lines) + '\n')
+    print(f"Wrote {OUTPUT_PATH}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `generate_env.py` script to create `config/setup.env` from environment vars
- document the new script in `README.md` and `config/README.md`

## Testing
- `pip install -r requirements/base.txt -r requirements/extra-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b3dfacdc832185942bd896d016a6