### PR TITLE
Add new feature cogs

### DIFF
--- a/cogs/logging_cog.py
+++ b/cogs/logging_cog.py
@@ -1,0 +1,38 @@
+import discord
+from discord.ext import commands
+
+COG_VERSION = "1.4"
+
+
+class LoggingCog(commands.Cog):
+    """Log joins, leaves, and message edits/deletes. Version 1.4."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    async def _log(self, guild: discord.Guild, text: str):
+        channel = discord.utils.get(guild.text_channels, name="bot-logs")
+        if channel:
+            await channel.send(text)
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member: discord.Member):
+        await self._log(member.guild, f"Member joined: {member.display_name}")
+
+    @commands.Cog.listener()
+    async def on_member_remove(self, member: discord.Member):
+        await self._log(member.guild, f"Member left: {member.display_name}")
+
+    @commands.Cog.listener()
+    async def on_message_delete(self, message: discord.Message):
+        if message.guild:
+            await self._log(message.guild, f"Message deleted in {message.channel}: {message.author.display_name}: {message.content}")
+
+    @commands.Cog.listener()
+    async def on_message_edit(self, before: discord.Message, after: discord.Message):
+        if before.guild and before.content != after.content:
+            await self._log(before.guild, f"Message edited in {before.channel}: {before.author.display_name}: {before.content} -> {after.content}")
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(LoggingCog(bot))

--- a/cogs/moderation_cog.py
+++ b/cogs/moderation_cog.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ext import commands
+import datetime
 
 COG_VERSION = "1.4"
 
@@ -9,6 +10,26 @@ class ModerationCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self.warnings: dict[int, int] = {}
+        self.blacklist = {"badword"}
+
+    @commands.command()
+    @commands.has_permissions(moderate_members=True)
+    async def mute(self, ctx, member: discord.Member, seconds: int, *, reason: str | None = None):
+        """Temporarily mute a member."""
+        try:
+            await member.timeout(datetime.timedelta(seconds=seconds), reason=reason)
+            await ctx.send(f"Muted {member.display_name} for {seconds} seconds.")
+        except Exception:
+            await ctx.send("Failed to mute.")
+
+    @commands.command()
+    @commands.has_permissions(moderate_members=True)
+    async def warn(self, ctx, member: discord.Member, *, reason: str | None = None):
+        """Warn a member and track warning count."""
+        count = self.warnings.get(member.id, 0) + 1
+        self.warnings[member.id] = count
+        await ctx.send(f"Warned {member.display_name}. Total warnings: {count}")
 
     @commands.command()
     @commands.has_permissions(kick_members=True)
@@ -30,6 +51,17 @@ class ModerationCog(commands.Cog):
         """Delete a number of recent messages."""
         deleted = await ctx.channel.purge(limit=amount + 1)
         await ctx.send(f"Deleted {len(deleted)-1} messages.", delete_after=5)
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.author.bot or not message.guild:
+            return
+        if any(word in message.content.lower() for word in self.blacklist):
+            await message.delete()
+            await message.channel.send(
+                f"{message.author.mention} watch your language!",
+                delete_after=5,
+            )
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/polls_cog.py
+++ b/cogs/polls_cog.py
@@ -1,0 +1,21 @@
+from discord.ext import commands
+
+COG_VERSION = "1.4"
+
+
+class PollsCog(commands.Cog):
+    """Quick reaction polls. Version 1.4."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command()
+    async def poll(self, ctx, *, question: str):
+        """Start a yes/no poll."""
+        msg = await ctx.send(f"\N{BAR CHART} **{question}**\nReact with \U0001F44D or \U0001F44E")
+        await msg.add_reaction("\U0001F44D")
+        await msg.add_reaction("\U0001F44E")
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(PollsCog(bot))

--- a/cogs/reaction_roles_cog.py
+++ b/cogs/reaction_roles_cog.py
@@ -1,0 +1,46 @@
+import discord
+from discord.ext import commands
+
+COG_VERSION = "1.4"
+
+
+class ReactionRolesCog(commands.Cog):
+    """Self-assign roles via reactions. Version 1.4."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.message_roles: dict[int, int] = {}
+
+    @commands.command()
+    @commands.has_permissions(manage_roles=True)
+    async def reactrole(self, ctx, role: discord.Role, *, text: str):
+        msg = await ctx.send(text)
+        await msg.add_reaction("\u2705")
+        self.message_roles[msg.id] = role.id
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        if payload.message_id not in self.message_roles or payload.member.bot:
+            return
+        role_id = self.message_roles[payload.message_id]
+        guild = self.bot.get_guild(payload.guild_id)
+        role = guild.get_role(role_id)
+        if role:
+            await payload.member.add_roles(role)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        if payload.message_id not in self.message_roles:
+            return
+        guild = self.bot.get_guild(payload.guild_id)
+        member = guild.get_member(payload.user_id)
+        if not member or member.bot:
+            return
+        role_id = self.message_roles[payload.message_id]
+        role = guild.get_role(role_id)
+        if role:
+            await member.remove_roles(role)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(ReactionRolesCog(bot))

--- a/cogs/reminder_cog.py
+++ b/cogs/reminder_cog.py
@@ -1,0 +1,25 @@
+import asyncio
+from discord.ext import commands
+
+COG_VERSION = "1.4"
+
+
+class ReminderCog(commands.Cog):
+    """User reminders and timers. Version 1.4."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command(name="remindme")
+    async def remindme(self, ctx, seconds: int, *, text: str):
+        """Remind the user after a number of seconds."""
+        await ctx.send(f"I'll remind you in {seconds} seconds.")
+        await asyncio.sleep(seconds)
+        try:
+            await ctx.author.send(f"Reminder: {text}")
+        except Exception:
+            await ctx.send(f"{ctx.author.mention} Reminder: {text}")
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(ReminderCog(bot))

--- a/cogs/starboard_cog.py
+++ b/cogs/starboard_cog.py
@@ -1,0 +1,35 @@
+import discord
+from discord.ext import commands
+
+COG_VERSION = "1.4"
+
+
+class StarboardCog(commands.Cog):
+    """Save popular messages to a starboard channel. Version 1.4."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.threshold = 3
+        self.starboard_cache: set[int] = set()
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        if str(payload.emoji) != "\u2B50":
+            return
+        if payload.message_id in self.starboard_cache:
+            return
+        channel = self.bot.get_channel(payload.channel_id)
+        message = await channel.fetch_message(payload.message_id)
+        if sum(1 for r in message.reactions if str(r.emoji) == "\u2B50" and r.count >= self.threshold):
+            starboard = discord.utils.get(channel.guild.text_channels, name="starboard")
+            if not starboard:
+                return
+            embed = discord.Embed(description=message.content, color=discord.Color.gold())
+            embed.set_author(name=message.author.display_name, icon_url=message.author.display_avatar.url)
+            embed.timestamp = message.created_at
+            await starboard.send(embed=embed)
+            self.starboard_cache.add(payload.message_id)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(StarboardCog(bot))

--- a/cogs/welcome_cog.py
+++ b/cogs/welcome_cog.py
@@ -1,0 +1,54 @@
+import discord
+from discord.ext import commands
+
+COG_VERSION = "1.4"
+
+WELCOME_LINES = {
+    "Grimm": "Another soul joins us... Welcome, {member}.",
+    "Bloom": "Yay! {member}, you're finally here! \U0001F389",
+    "Curse": "Heh, {member} stumbled into our lair.",
+    "default": "Welcome {member}!",
+}
+
+GOODBYE_LINES = {
+    "Grimm": "Farewell, {member}. Don't get lost out there.",
+    "Bloom": "Aww, {member} left the party. Come back soon!",
+    "Curse": "Bye-bye {member}, thanks for the chaos.",
+    "default": "Goodbye {member}.",
+}
+
+
+class WelcomeCog(commands.Cog):
+    """Send welcome and goodbye messages and auto-assign roles. Version 1.4."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    def _line(self, name: str, member: discord.Member, table: dict[str, str]) -> str:
+        template = table.get(name, table["default"])
+        return template.format(member=member.mention if "welcome" in template else member.display_name)
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member: discord.Member):
+        guild = member.guild
+        role = discord.utils.get(guild.roles, name="Member")
+        if role:
+            await member.add_roles(role)
+        channel = discord.utils.get(guild.text_channels, name="general") or guild.text_channels[0]
+        line = self._line(self.bot.user.name if self.bot.user else "default", member, WELCOME_LINES)
+        await channel.send(line)
+        try:
+            await member.send(line)
+        except discord.Forbidden:
+            pass
+
+    @commands.Cog.listener()
+    async def on_member_remove(self, member: discord.Member):
+        guild = member.guild
+        channel = discord.utils.get(guild.text_channels, name="general") or guild.text_channels[0]
+        line = self._line(self.bot.user.name if self.bot.user else "default", member, GOODBYE_LINES)
+        await channel.send(line)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(WelcomeCog(bot))

--- a/cogs/xp_cog.py
+++ b/cogs/xp_cog.py
@@ -1,0 +1,46 @@
+import discord
+from discord.ext import commands
+
+COG_VERSION = "1.4"
+
+
+class XPCog(commands.Cog):
+    """Simple chat-based XP and leveling. Version 1.4."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.xp: dict[int, int] = {}
+
+    def _level(self, xp: int) -> int:
+        return int(xp ** 0.5)
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.author.bot or not message.guild:
+            return
+        user_id = message.author.id
+        self.xp[user_id] = self.xp.get(user_id, 0) + 1
+
+    @commands.command()
+    async def rank(self, ctx, member: discord.Member | None = None):
+        member = member or ctx.author
+        xp = self.xp.get(member.id, 0)
+        level = self._level(xp)
+        await ctx.send(f"{member.display_name} is level {level} with {xp} XP.")
+
+    @commands.command()
+    async def leaderboard(self, ctx):
+        if not self.xp:
+            await ctx.send("Nobody has XP yet.")
+            return
+        top = sorted(self.xp.items(), key=lambda kv: kv[1], reverse=True)[:5]
+        lines = []
+        for idx, (uid, xp) in enumerate(top, 1):
+            member = ctx.guild.get_member(uid)
+            name = member.display_name if member else str(uid)
+            lines.append(f"{idx}. {name} - {xp} XP")
+        await ctx.send("Leaderboard:\n" + "\n".join(lines))
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(XPCog(bot))


### PR DESCRIPTION
## Summary
- add WelcomeCog for welcome/goodbye messages
- add XPCog for simple leveling
- add ReminderCog for timers
- add ReactionRolesCog for self-assign roles
- add PollsCog for quick polls
- add StarboardCog to save starred messages
- add LoggingCog for basic event logging
- extend ModerationCog with mute, warn and basic filtering

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b7415e50832195e7f555efece026