### PR TITLE
Consolidate API key loading

### DIFF
--- a/bloom_bot.py
+++ b/bloom_bot.py
@@ -19,7 +19,7 @@ import asyncio
 import openai
 import datetime
 import logging
-from config.settings import load_config
+from config.settings import load_config, get_env_vars
 from pathlib import Path
 import yt_dlp
 from src.logger import setup_logging, log_message
@@ -43,10 +43,12 @@ if not ENV_PATH.exists():
     raise SystemExit("config/setup.env missing. Run 'python install.py' first.")
 load_config({"BLOOM_DISCORD_TOKEN"})
 DISCORD_TOKEN = os.getenv("BLOOM_DISCORD_TOKEN")
-BLOOM_API_KEY_1 = os.getenv("BLOOM_API_KEY_1")
-BLOOM_API_KEY_2 = os.getenv("BLOOM_API_KEY_2")
-BLOOM_API_KEY_3 = os.getenv("BLOOM_API_KEY_3")
-BLOOM_OPENAI_KEY = os.getenv("BLOOM_OPENAI_KEY")
+BLOOM_API_KEY_1, BLOOM_API_KEY_2, BLOOM_API_KEY_3, BLOOM_OPENAI_KEY = get_env_vars(
+    "BLOOM_API_KEY_1",
+    "BLOOM_API_KEY_2",
+    "BLOOM_API_KEY_3",
+    "BLOOM_OPENAI_KEY",
+)
 BLOOM_GPT_ENABLED = os.getenv("BLOOM_GPT_ENABLED", "true").lower() == "true"
 BLOOM_OPENAI_MODEL = os.getenv("BLOOM_OPENAI_MODEL", "gpt-3.5-turbo")
 

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -6,14 +6,17 @@ import yt_dlp
 import asyncio
 from bloom_bot import perform_drama, BLOOM_COMPLIMENTS
 from src.logger import log_message
+from config.settings import get_env_vars
 
 COG_VERSION = "1.4"
 
 # Environment values are read from the parent process
 DISCORD_TOKEN = os.getenv("BLOOM_DISCORD_TOKEN")
-BLOOM_API_KEY_1 = os.getenv("BLOOM_API_KEY_1")
-BLOOM_API_KEY_2 = os.getenv("BLOOM_API_KEY_2")
-BLOOM_API_KEY_3 = os.getenv("BLOOM_API_KEY_3")
+BLOOM_API_KEY_1, BLOOM_API_KEY_2, BLOOM_API_KEY_3 = get_env_vars(
+    "BLOOM_API_KEY_1",
+    "BLOOM_API_KEY_2",
+    "BLOOM_API_KEY_3",
+)
 EPIC_VIDEO_URL = "https://m.youtube.com/watch?v=6K-eMKjo1bs"
 
 

--- a/cogs/curse_cog.py
+++ b/cogs/curse_cog.py
@@ -5,14 +5,17 @@ import os
 import asyncio
 import datetime
 from src.logger import log_message
+from config.settings import get_env_vars
 
 COG_VERSION = "1.4"
 
 # Environment values are read from the parent process
 DISCORD_TOKEN = os.getenv("CURSE_DISCORD_TOKEN")
-CURSE_API_KEY_1 = os.getenv("CURSE_API_KEY_1")
-CURSE_API_KEY_2 = os.getenv("CURSE_API_KEY_2")
-CURSE_API_KEY_3 = os.getenv("CURSE_API_KEY_3")
+CURSE_API_KEY_1, CURSE_API_KEY_2, CURSE_API_KEY_3 = get_env_vars(
+    "CURSE_API_KEY_1",
+    "CURSE_API_KEY_2",
+    "CURSE_API_KEY_3",
+)
 
 CURSE_BLOCK_ROLES = ["Grimm's Shield", "Bloom's Blessing"]
 

--- a/cogs/grimm_cog.py
+++ b/cogs/grimm_cog.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands, tasks
 import random
 import os
+from config.settings import get_env_vars
 
 import socketio
 from src.logger import log_message
@@ -10,9 +11,12 @@ COG_VERSION = "1.4"
 
 # Environment values are read from the parent process
 DISCORD_TOKEN = os.getenv("GRIMM_DISCORD_TOKEN")
-GRIMM_API_KEY_1 = os.getenv("GRIMM_API_KEY_1")
-GRIMM_API_KEY_2 = os.getenv("GRIMM_API_KEY_2")
-GRIMM_API_KEY_3 = os.getenv("GRIMM_API_KEY_3")
+GRIMM_API_KEY_1, GRIMM_API_KEY_2, GRIMM_API_KEY_3, _ = get_env_vars(
+    "GRIMM_API_KEY_1",
+    "GRIMM_API_KEY_2",
+    "GRIMM_API_KEY_3",
+    "GRIMM_OPENAI_KEY",
+)
 SOCKET_SERVER = os.getenv("SOCKET_SERVER_URL", "http://localhost:5000")
 
 sio = socketio.Client()

--- a/config/README.md
+++ b/config/README.md
@@ -56,6 +56,9 @@ features or `SOCKET_SERVER_URL` if you want status reporting.
 
 3. Save the file. Any bot you run will read these values automatically.
 
+Bots load related API keys in a single call using `get_env_vars` from
+`config.settings` for cleaner code.
+
 Do **not** commit `setup.env` to git. Keep it private.
 
 Refer to [`../INSTALL.md`](../INSTALL.md) for instructions on installing the

--- a/config/settings.py
+++ b/config/settings.py
@@ -45,3 +45,8 @@ def validate_template() -> list[str]:
     template_vars = parse_vars(TEMPLATE_PATH)
     setup_vars = parse_vars(ENV_PATH) if ENV_PATH.exists() else set()
     return sorted(template_vars - setup_vars)
+
+
+def get_env_vars(*names: str):
+    """Return multiple environment variables at once."""
+    return map(os.getenv, names)

--- a/curse_bot.py
+++ b/curse_bot.py
@@ -18,7 +18,7 @@ import asyncio
 import openai
 import datetime
 import logging
-from config.settings import load_config
+from config.settings import load_config, get_env_vars
 from pathlib import Path
 from src.logger import setup_logging, log_message
 
@@ -41,10 +41,12 @@ if not ENV_PATH.exists():
     raise SystemExit("config/setup.env missing. Run 'python install.py' first.")
 load_config({"CURSE_DISCORD_TOKEN"})
 DISCORD_TOKEN = os.getenv("CURSE_DISCORD_TOKEN")
-CURSE_API_KEY_1 = os.getenv("CURSE_API_KEY_1")
-CURSE_API_KEY_2 = os.getenv("CURSE_API_KEY_2")
-CURSE_API_KEY_3 = os.getenv("CURSE_API_KEY_3")
-CURSE_OPENAI_KEY = os.getenv("CURSE_OPENAI_KEY")
+CURSE_API_KEY_1, CURSE_API_KEY_2, CURSE_API_KEY_3, CURSE_OPENAI_KEY = get_env_vars(
+    "CURSE_API_KEY_1",
+    "CURSE_API_KEY_2",
+    "CURSE_API_KEY_3",
+    "CURSE_OPENAI_KEY",
+)
 CURSE_GPT_ENABLED = os.getenv("CURSE_GPT_ENABLED", "true").lower() == "true"
 CURSE_OPENAI_MODEL = os.getenv("CURSE_OPENAI_MODEL", "gpt-3.5-turbo")
 

--- a/grimm_bot.py
+++ b/grimm_bot.py
@@ -19,7 +19,7 @@ import openai
 import datetime
 
 import logging
-from config.settings import load_config
+from config.settings import load_config, get_env_vars
 import grimm_utils
 import random
 import socketio
@@ -42,10 +42,12 @@ logger = logging.getLogger(__name__)
 # Load shared configuration
 load_config({"GRIMM_DISCORD_TOKEN"})
 DISCORD_TOKEN = os.getenv("GRIMM_DISCORD_TOKEN")
-GRIMM_API_KEY_1 = os.getenv("GRIMM_API_KEY_1")
-GRIMM_API_KEY_2 = os.getenv("GRIMM_API_KEY_2")
-GRIMM_API_KEY_3 = os.getenv("GRIMM_API_KEY_3")
-GRIMM_OPENAI_KEY = os.getenv("GRIMM_OPENAI_KEY")
+GRIMM_API_KEY_1, GRIMM_API_KEY_2, GRIMM_API_KEY_3, GRIMM_OPENAI_KEY = get_env_vars(
+    "GRIMM_API_KEY_1",
+    "GRIMM_API_KEY_2",
+    "GRIMM_API_KEY_3",
+    "GRIMM_OPENAI_KEY",
+)
 GRIMM_GPT_ENABLED = os.getenv("GRIMM_GPT_ENABLED", "true").lower() == "true"
 GRIMM_OPENAI_MODEL = os.getenv("GRIMM_OPENAI_MODEL", "gpt-3.5-turbo")
 SOCKET_SERVER = os.getenv("SOCKET_SERVER_URL", "http://localhost:5000")


### PR DESCRIPTION
## Summary
- add `get_env_vars` helper to return multiple env vars
- load all API keys for each bot in a single call
- document the helper in config README

## Testing
- `pip install -q -r requirements/base.txt`
- `pip install -q pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c591c2388321ad8d5a5702c7bb7f