### PR TITLE
Rotate OpenAI API keys and update docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,6 +72,8 @@ Prefer to get your paws dirty?
       - `DISCORD_TOKEN`
       - `OPENAI_API_KEY`
       Leave a value blank to keep any existing entry.
+      Additional OpenAI keys (`*_API_KEY_1`–`*_API_KEY_3`) will be used in
+      rotation when provided.
    4. **Choose bot** – finally you'll see a menu:
       `1. GrimmBot`, `2. BloomBot`, `3. CurseBot`, `4. GoonBot`, `5. All bots`, `0. Exit`.
       Enter a number to launch a bot immediately or `0` to finish without

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ To run these bots you must provide your own Discord, OpenAI and any other requir
 - **Keep your keys secret.** Never commit them to public repositories.
 - All API usage is governed by each provider's terms of service.
 - Each bot can be given a unique `*_OPENAI_KEY` and `*_GPT_ENABLED` flag in
-  `config/setup.env` to enable or disable its ChatGPT commands.
+  `config/setup.env` to enable or disable its ChatGPT commands. If you supply
+  additional keys using `*_API_KEY_1`‑`*_API_KEY_3` they will be cycled
+  automatically to avoid hitting rate limits.
 - The author is not responsible for any API misuse, key theft, account bans, or charges incurred.
 
 ## What lurks inside

--- a/config/README.md
+++ b/config/README.md
@@ -37,17 +37,17 @@ features or `SOCKET_SERVER_URL` if you want status reporting.
 | Variable | Description |
 | --- | --- |
 | `GRIMM_DISCORD_TOKEN` | Discord bot token for Grimm |
-| `GRIMM_API_KEY_1`-`GRIMM_API_KEY_3` | Custom API keys used by Grimm cogs |
-| `GRIMM_OPENAI_KEY` | API key for Grimm's ChatGPT features |
+| `GRIMM_API_KEY_1`-`GRIMM_API_KEY_3` | Additional OpenAI keys rotated for Grimm |
+| `GRIMM_OPENAI_KEY` | Primary OpenAI key for Grimm's ChatGPT |
 | `GRIMM_GPT_ENABLED` | Toggle Grimm's ChatGPT commands |
 | `SOCKET_SERVER_URL` | Optional Socket.IO status endpoint |
 | `BLOOM_DISCORD_TOKEN` | Discord bot token for Bloom |
-| `BLOOM_API_KEY_1`-`BLOOM_API_KEY_3` | API keys for Bloom-specific features |
-| `BLOOM_OPENAI_KEY` | API key for Bloom's ChatGPT features |
+| `BLOOM_API_KEY_1`-`BLOOM_API_KEY_3` | Extra OpenAI keys rotated for Bloom |
+| `BLOOM_OPENAI_KEY` | Primary OpenAI key for Bloom's ChatGPT |
 | `BLOOM_GPT_ENABLED` | Toggle Bloom's ChatGPT commands |
 | `CURSE_DISCORD_TOKEN` | Discord bot token for Curse |
-| `CURSE_API_KEY_1`-`CURSE_API_KEY_3` | API keys for Curse's cogs |
-| `CURSE_OPENAI_KEY` | API key for Curse's ChatGPT features |
+| `CURSE_API_KEY_1`-`CURSE_API_KEY_3` | Extra OpenAI keys rotated for Curse |
+| `CURSE_OPENAI_KEY` | Primary OpenAI key for Curse's ChatGPT |
 | `CURSE_GPT_ENABLED` | Toggle Curse's ChatGPT commands |
 | `DISCORD_TOKEN` | Token for the unified GoonBot |
 | `OPENAI_API_KEY` | Enables GPT-based commands |

--- a/src/api_utils.py
+++ b/src/api_utils.py
@@ -1,0 +1,15 @@
+from itertools import cycle
+from typing import Iterable
+
+
+class ApiKeyCycle:
+    """Cycle through multiple API keys to spread usage."""
+
+    def __init__(self, keys: Iterable[str]):
+        clean_keys = [k for k in keys if k]
+        if not clean_keys:
+            raise ValueError("No API keys provided")
+        self._cycle = cycle(clean_keys)
+
+    def next(self) -> str:
+        return next(self._cycle)


### PR DESCRIPTION
## Summary
- rotate through provided OpenAI keys using new `ApiKeyCycle` helper
- update Grimm, Bloom and Curse bots to use sequential keys
- update GPT-based cogs to pull the next key on each request
- document new behaviour in README, INSTALL and config docs
- ensure flake8 compliance

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c958a5548321bf2ce91de86183b1