### PR TITLE
Add tests for ApiKeyCycle rotation

### DIFF
--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.api_utils import ApiKeyCycle
+
+
+def test_api_key_cycle_basic():
+    cycle = ApiKeyCycle(["k1", "k2", "k3"])
+    assert cycle.next() == "k1"
+    assert cycle.next() == "k2"
+    assert cycle.next() == "k3"
+    # Should wrap around
+    assert cycle.next() == "k1"
+
+
+def test_api_key_cycle_empty():
+    with pytest.raises(ValueError):
+        ApiKeyCycle(["", None])


### PR DESCRIPTION
## Summary
- add a new `tests/test_api_utils.py` covering `ApiKeyCycle`
- verify cycling order and empty-key handling

## Testing
- `pip install -r requirements/extra-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d28092488321b7987c04c6dd6955