### PR TITLE
Update docs and bump version numbers

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-# Goon Squad Bots - Installation Guide (v2.0.0)
+# Goon Squad Bots - Installation Guide (v2.0.1)
 
 Curse here. Let's get these bots running on your machine. This works on
 Windows, macOS, or Linux—take your pick.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Hello, puny mortals. **Curse** speaking here. This repository holds me and my fellow goons in all our chaotic glory. Clone it from [GitHub](https://github.com/The-w0rst/grimmbot) if you dare and run whichever of us you want. I'm lightweight and unpredictable, just like the others.
 
-**Current build: v2.0.0** – official release
+**Current build: v2.0.1** – official release
 
 ## Quickstart
 1. Run the bootstrap script:

--- a/cogs/admin_cog.py
+++ b/cogs/admin_cog.py
@@ -1,6 +1,6 @@
 from discord.ext import commands
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class AdminCog(commands.Cog):

--- a/cogs/announcement_cog.py
+++ b/cogs/announcement_cog.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands, tasks
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 # Server reference information for quick access
 SERVER_ROLES = [

--- a/cogs/bloom_cog.py
+++ b/cogs/bloom_cog.py
@@ -8,7 +8,7 @@ from bloom_bot import perform_drama, BLOOM_COMPLIMENTS
 from src.logger import log_message
 from config.settings import get_env_vars
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 # Environment values are read from the parent process
 DISCORD_TOKEN = os.getenv("BLOOM_DISCORD_TOKEN")

--- a/cogs/curse_cog.py
+++ b/cogs/curse_cog.py
@@ -7,7 +7,7 @@ import datetime
 from src.logger import log_message
 from config.settings import get_env_vars
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 # Environment values are read from the parent process
 DISCORD_TOKEN = os.getenv("CURSE_DISCORD_TOKEN")

--- a/cogs/cyberpunk_campaign_cog.py
+++ b/cogs/cyberpunk_campaign_cog.py
@@ -4,7 +4,7 @@ import openai
 from discord.ext import commands
 from src.api_utils import ApiKeyCycle
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 # Environment values are read from the parent process
 try:

--- a/cogs/fun_cog.py
+++ b/cogs/fun_cog.py
@@ -1,7 +1,7 @@
 from discord.ext import commands
 import random
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class FunCog(commands.Cog):

--- a/cogs/goon_cog.py
+++ b/cogs/goon_cog.py
@@ -1,7 +1,7 @@
 import random
 from discord.ext import commands
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class GoonCog(commands.Cog):

--- a/cogs/gpt_cog.py
+++ b/cogs/gpt_cog.py
@@ -3,7 +3,7 @@ import openai
 from discord.ext import commands
 from src.api_utils import ApiKeyCycle
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 # Environment values are read from the parent process
 try:

--- a/cogs/grimm_cog.py
+++ b/cogs/grimm_cog.py
@@ -7,7 +7,7 @@ from config.settings import get_env_vars
 import socketio
 from src.logger import log_message
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 # Environment values are read from the parent process
 DISCORD_TOKEN = os.getenv("GRIMM_DISCORD_TOKEN")

--- a/cogs/grimm_extra_cog.py
+++ b/cogs/grimm_extra_cog.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 
 from . import grimm_utils
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class GrimmExtraCog(commands.Cog):

--- a/cogs/help_cog.py
+++ b/cogs/help_cog.py
@@ -1,6 +1,6 @@
 from discord.ext import commands
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 # Short help messages for each bot so they can be reused in other commands
 GRIMM_HELP = (

--- a/cogs/jojo_cog.py
+++ b/cogs/jojo_cog.py
@@ -3,7 +3,7 @@ import discord
 import datetime
 import random
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 JOJO_DISPLAY_NAME = "JoJo is bizarre"
 EMMA_NAME = "Emma"

--- a/cogs/logging_cog.py
+++ b/cogs/logging_cog.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class LoggingCog(commands.Cog):

--- a/cogs/moderation_cog.py
+++ b/cogs/moderation_cog.py
@@ -2,7 +2,7 @@ import discord
 from discord.ext import commands
 import datetime
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class ModerationCog(commands.Cog):

--- a/cogs/music_cog.py
+++ b/cogs/music_cog.py
@@ -7,7 +7,7 @@ import requests
 from bs4 import BeautifulSoup
 from typing import Dict, List
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class MusicCog(commands.Cog):

--- a/cogs/polls_cog.py
+++ b/cogs/polls_cog.py
@@ -1,6 +1,6 @@
 from discord.ext import commands
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class PollsCog(commands.Cog):

--- a/cogs/reaction_roles_cog.py
+++ b/cogs/reaction_roles_cog.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class ReactionRolesCog(commands.Cog):

--- a/cogs/reminder_cog.py
+++ b/cogs/reminder_cog.py
@@ -1,7 +1,7 @@
 import asyncio
 from discord.ext import commands
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class ReminderCog(commands.Cog):

--- a/cogs/starboard_cog.py
+++ b/cogs/starboard_cog.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class StarboardCog(commands.Cog):

--- a/cogs/trivia_cog.py
+++ b/cogs/trivia_cog.py
@@ -2,7 +2,7 @@ import random
 import asyncio
 from discord.ext import commands
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 NUMBER_WORDS = {
     0: "zero",

--- a/cogs/welcome_cog.py
+++ b/cogs/welcome_cog.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 WELCOME_LINES = {
     "Grimm": "Another soul joins us... Welcome, {member}.",

--- a/cogs/xp_cog.py
+++ b/cogs/xp_cog.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
 
-COG_VERSION = "1.4"
+COG_VERSION = "1.5"
 
 
 class XPCog(commands.Cog):

--- a/command.txt
+++ b/command.txt
@@ -1,4 +1,4 @@
-# Grimmbot Command Reference (v2.0.0)
+# Grimmbot Command Reference (v2.0.1)
 
 This file lists every command exposed by the included cogs. Use the bot prefix for your chosen personality (`!`, `*` or `?`) before each command.
 

--- a/configure.py
+++ b/configure.py
@@ -7,7 +7,7 @@ import logging
 
 TEMPLATE_PATH = Path("config/env_template.env")
 SETUP_PATH = Path("config/setup.env")
-VERSION = "1.4"
+VERSION = "1.5"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,3 +19,7 @@
 ## v2.0.0
 - Official release with a complete command reference.
 - All code reviewed for flake8 compliance.
+
+## v2.0.1
+- Added `ApiKeyCycle` utility for rotating OpenAI keys.
+- Formatted entire codebase with Black and removed E203 ignore from flake8.

--- a/docs/cogs_overview.md
+++ b/docs/cogs_overview.md
@@ -1,7 +1,7 @@
 # Cogs Overview
 
 Curse here again. Here's a quick summary of each cog bundled with Grimmbot and
-what mischief it adds. All cogs are currently **v2.0.0**.
+what mischief it adds. All cogs are currently **v2.0.1**.
 
 | Cog | Purpose |
 | --- | ------- |

--- a/install.py
+++ b/install.py
@@ -26,7 +26,7 @@ BLUE = Fore.BLUE + Style.BRIGHT
 ORANGE = Fore.LIGHTYELLOW_EX + Style.BRIGHT
 RESET = Style.RESET_ALL
 
-VERSION = "1.7"
+VERSION = "1.8"
 
 TEMPLATE_PATH = Path("config/env_template.env")
 SETUP_PATH = Path("config/setup.env")

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ python_requires = ">=3.10"
 
 setup(
     name="grimmbot",
-    version="0.1.0",
+    version="0.1.1",
     packages=find_packages(include=["cogs", "cogs.*"]),
     py_modules=["grimm_bot", "bloom_bot", "curse_bot", "goon_bot"],
     install_requires=install_requires,


### PR DESCRIPTION
## Summary
- bump all version constants and docs to 2.0.1
- note new API key rotation and formatting in the changelog
- keep flake8 clean

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888e153ba2c83219d558dbe0218b352